### PR TITLE
Fix CurrentUserDetails for @PreAuthorize calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ repositories {
 
 
 dependencies {
-    compile("org.springframework.cloud:spring-cloud-starter-oauth2")
     compile("org.springframework.boot:spring-boot-starter-data-jpa")
     compile("org.springframework.boot:spring-boot-starter-security")
     compile("org.springframework.boot:spring-boot-starter-web")

--- a/src/main/java/ch/wisv/areafiftylan/service/CurrentUserService.java
+++ b/src/main/java/ch/wisv/areafiftylan/service/CurrentUserService.java
@@ -1,10 +1,8 @@
 package ch.wisv.areafiftylan.service;
 
-import org.springframework.security.core.userdetails.UserDetails;
-
 /**
  * The CurrentUserService is for permissions that require some logic to be determined.
  */
 public interface CurrentUserService {
-    boolean canAccessUser(UserDetails currentUser, Long userId);
+    boolean canAccessUser(Object principal, Long userId);
 }

--- a/src/main/java/ch/wisv/areafiftylan/service/CurrentUserServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/service/CurrentUserServiceImpl.java
@@ -9,12 +9,15 @@ import org.springframework.stereotype.Service;
 public class CurrentUserServiceImpl implements CurrentUserService {
 
     @Override
-    public boolean canAccessUser(UserDetails currentUser, Long userId) {
-        if (currentUser != null) {
-            User user = (User) currentUser;
+    public boolean canAccessUser(Object principal, Long userId) {
+
+        if (principal instanceof UserDetails) {
+            User user = (User) principal;
             return user.getId().equals(userId) || user.getAuthorities().contains(Role.ADMIN);
         } else {
             return false;
         }
+
+
     }
 }


### PR DESCRIPTION
The principal object can be a String instead of a UserDetails when the user is anonymous. This fix accounts for that possibility.