### PR TITLE
Split UserRestController

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/controller/CurrentUserRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/controller/CurrentUserRestController.java
@@ -7,12 +7,14 @@ import ch.wisv.areafiftylan.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
 
 import static ch.wisv.areafiftylan.util.ResponseEntityBuilder.createResponseEntity;
 
@@ -49,11 +51,15 @@ public class CurrentUserRestController {
      * This method accepts PUT requests on /users/current. It replaces all fields with the new user provided in the
      * RequestBody and resets the profile fields. All references to the old user are maintained (Team membership ect).
      *
+     * This is limited to admin use, because users should not be able to change their core information with a
+     * single PUT request. Use the profile mapping for editing profile fields.
+     *
      * @param input A UserDTO object containing data of the new user
      *
      * @return The User object.
      */
     @RequestMapping(method = RequestMethod.PUT)
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<?> replaceCurrentUser(@Validated @RequestBody UserDTO input, Authentication auth) {
         User user = (User) auth.getPrincipal();
         user = userService.replace(user.getId(), input);
@@ -61,6 +67,7 @@ public class CurrentUserRestController {
     }
 
     @RequestMapping(method = RequestMethod.PATCH)
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<?> updateCurrentUser(@Validated @RequestBody UserDTO input, Authentication auth) {
         //TODO: Differentiate between PATCH and PUT
         User user = (User) auth.getPrincipal();

--- a/src/main/java/ch/wisv/areafiftylan/controller/CurrentUserRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/controller/CurrentUserRestController.java
@@ -1,0 +1,70 @@
+package ch.wisv.areafiftylan.controller;
+
+
+import ch.wisv.areafiftylan.dto.UserDTO;
+import ch.wisv.areafiftylan.model.User;
+import ch.wisv.areafiftylan.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import static ch.wisv.areafiftylan.util.ResponseEntityBuilder.createResponseEntity;
+
+@RestController
+@RequestMapping("/users/current")
+@PreAuthorize("isAuthenticated()")
+public class CurrentUserRestController {
+
+    private UserService userService;
+
+    @Autowired
+    CurrentUserRestController(UserService userService) {
+        this.userService = userService;
+    }
+
+    /**
+     * Get the User currently logged in. Because our User model implements the Spring Security UserDetails, this can be
+     * directly derived from the Authentication object which is automatically added. Returns a not-found entity if
+     * there's no user logged in. Returns the user
+     *
+     * @param auth Current Authentication object, automatically taken from the SecurityContext
+     *
+     * @return The currently logged in User.
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    public ResponseEntity<?> getCurrentUser(Authentication auth) {
+        // Get the currently logged in user from the autowired Authentication object.
+        UserDetails currentUser = (UserDetails) auth.getPrincipal();
+        User user = userService.getUserByUsername(currentUser.getUsername()).get();
+        return new ResponseEntity<>(user, HttpStatus.OK);
+    }
+
+    /**
+     * This method accepts PUT requests on /users/current. It replaces all fields with the new user provided in the
+     * RequestBody and resets the profile fields. All references to the old user are maintained (Team membership ect).
+     *
+     * @param input A UserDTO object containing data of the new user
+     *
+     * @return The User object.
+     */
+    @RequestMapping(method = RequestMethod.PUT)
+    public ResponseEntity<?> replaceCurrentUser(@Validated @RequestBody UserDTO input, Authentication auth) {
+        User user = (User) auth.getPrincipal();
+        user = userService.replace(user.getId(), input);
+        return createResponseEntity(HttpStatus.OK, "User successfully replaced", user);
+    }
+
+    @RequestMapping(method = RequestMethod.PATCH)
+    public ResponseEntity<?> updateCurrentUser(@Validated @RequestBody UserDTO input, Authentication auth) {
+        //TODO: Differentiate between PATCH and PUT
+        User user = (User) auth.getPrincipal();
+        user = userService.replace(user.getId(), input);
+        return createResponseEntity(HttpStatus.OK, "User successfully replaced", user);
+    }
+}

--- a/src/main/java/ch/wisv/areafiftylan/controller/UserProfileRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/controller/UserProfileRestController.java
@@ -1,0 +1,98 @@
+package ch.wisv.areafiftylan.controller;
+
+import ch.wisv.areafiftylan.dto.ProfileDTO;
+import ch.wisv.areafiftylan.model.Profile;
+import ch.wisv.areafiftylan.model.User;
+import ch.wisv.areafiftylan.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import static ch.wisv.areafiftylan.util.ResponseEntityBuilder.createResponseEntity;
+
+@RestController
+@RequestMapping("/users/current")
+@PreAuthorize("isAuthenticated()")
+public class UserProfileRestController {
+
+    private UserService userService;
+
+    @Autowired
+    UserProfileRestController(UserService userService) {
+        this.userService = userService;
+    }
+
+    /**
+     * Add a profile to a user. An empty profile is created when a user is created, so this method fills the existing
+     * fields
+     *
+     * @param userId The userId of the user to which the profile needs to be added
+     * @param input  A representation of the profile
+     *
+     * @return The user with the new profile
+     */
+    @PreAuthorize("@currentUserServiceImpl.canAccessUser(principal, #userId)")
+    @RequestMapping(value = "/{userId}/profile", method = RequestMethod.POST)
+    public ResponseEntity<?> addProfile(@PathVariable Long userId, @Validated @RequestBody ProfileDTO input) {
+        User user = userService.addProfile(userId, input);
+
+        // Create HttpHeaders to include the location of the newly created profile
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setLocation(
+                ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}/profile").buildAndExpand(user.getId())
+                        .toUri());
+
+        return createResponseEntity(HttpStatus.CREATED, httpHeaders,
+                "Profile succesfully created at" + httpHeaders.getLocation(), user.getProfile());
+    }
+
+    /**
+     * Add a profile to the current user. An empty profile is created when a user is created, so this method fills the
+     * existing fields
+     *
+     * @param input A representation of the profile
+     *
+     * @return The user with the new profile
+     */
+    @PreAuthorize("isAuthenticated()")
+    @RequestMapping(value = "/current/profile", method = RequestMethod.POST)
+    public ResponseEntity<?> addProfile(@Validated @RequestBody ProfileDTO input, Authentication auth) {
+        return this.addProfile(((User) auth.getPrincipal()).getId(), input);
+    }
+
+    /**
+     * Change the profile fields of the User. Basically the same as the POST request.
+     *
+     * @param userId The userId of the user to which the profile needs to be added
+     * @param input  A representation of the profile
+     *
+     * @return The user with the changed profile
+     */
+    @PreAuthorize("@currentUserServiceImpl.canAccessUser(principal, #userId)")
+    @RequestMapping(value = "/{userId}/profile", method = RequestMethod.PUT)
+    public ResponseEntity<?> changeProfile(@PathVariable Long userId, @Validated @RequestBody ProfileDTO input) {
+        User user = userService.changeProfile(userId, input);
+
+        return createResponseEntity(HttpStatus.OK, "Profile successfully updated", user.getProfile());
+    }
+
+    /**
+     * Resets the profile fields to null. The profile can't actually be deleted as it is a required field.
+     *
+     * @param userId The userId of the user which needs the profile reset
+     *
+     * @return Empty body with StatusCode OK.
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @RequestMapping(value = "/{userId}/profile", method = RequestMethod.DELETE)
+    public ResponseEntity<?> resetProfile(@PathVariable Long userId) {
+        Profile profile = userService.resetProfile(userId);
+        return createResponseEntity(HttpStatus.OK, "Profile successfully reset", profile);
+    }
+}

--- a/src/main/java/ch/wisv/areafiftylan/controller/UserProfileRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/controller/UserProfileRestController.java
@@ -17,8 +17,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import static ch.wisv.areafiftylan.util.ResponseEntityBuilder.createResponseEntity;
 
 @RestController
-@RequestMapping("/users/current")
-@PreAuthorize("isAuthenticated()")
+@RequestMapping("/users")
 public class UserProfileRestController {
 
     private UserService userService;

--- a/src/main/java/ch/wisv/areafiftylan/exception/GlobalControllerExceptionHandler.java
+++ b/src/main/java/ch/wisv/areafiftylan/exception/GlobalControllerExceptionHandler.java
@@ -1,0 +1,22 @@
+package ch.wisv.areafiftylan.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import static ch.wisv.areafiftylan.util.ResponseEntityBuilder.createResponseEntity;
+
+/**
+ * This class handles exceptions for ALL Controllers. Whenever a Controller throws an exception that is listed here, the
+ * corresponding method will be used to handle the exception.
+ */
+@ControllerAdvice
+class GlobalControllerExceptionHandler {
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<?> handleAccessDeniedException(AccessDeniedException ex) {
+        return createResponseEntity(HttpStatus.FORBIDDEN, "Access denied");
+    }
+}

--- a/src/test/java/ch/wisv/areafiftylan/UserRestIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/UserRestIntegrationTest.java
@@ -10,7 +10,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.RestAssured.when;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
@@ -79,13 +78,6 @@ public class UserRestIntegrationTest extends IntegrationTest {
                 then().log().all().statusCode(HttpStatus.SC_FORBIDDEN);
     }
 
-    // PROFILE
-    @Test
-    public void testGetCurrentProfileAnonymous() {
-        when().get("/users/current/profile").
-                then().statusCode(HttpStatus.SC_FORBIDDEN);
-    }
-
     // GET CURRENT USER AS USER
     @Test
     public void testGetCurrentUserUser() {
@@ -95,16 +87,6 @@ public class UserRestIntegrationTest extends IntegrationTest {
                 body("username", equalTo(user.getUsername())).
                 body("email", equalTo(user.getEmail())).
                 body("authorities", hasItem("ROLE_USER"));
-    }
-
-    // PROFILE
-    @Test
-    public void testGetCurrentProfileUser() {
-        given().auth().form("user", "password", formAuthConfig).
-                when().get("/users/current/profile").
-                then().statusCode(HttpStatus.SC_OK).
-                body("firstName", equalTo(user.getProfile().getFirstName())).
-                body("gender", equalTo(user.getProfile().getGender().toString()));
     }
 
     // GET CURRENT USER AS ADMIN
@@ -118,26 +100,10 @@ public class UserRestIntegrationTest extends IntegrationTest {
                 body("authorities", hasItem("ROLE_ADMIN"));
     }
 
-    // PROFILE
-    @Test
-    public void testGetCurrentProfileAdmin() {
-        given().auth().form("admin", "password", formAuthConfig).
-                when().get("/users/current/profile").
-                then().statusCode(HttpStatus.SC_OK).
-                body("firstName", equalTo(admin.getProfile().getFirstName())).
-                body("gender", equalTo(admin.getProfile().getGender().toString()));
-    }
-
     // GET OTHER ROLE_USER AS ANONYMOUS
     @Test
     public void testGetOtherUserAnonymous() {
         when().get("/users/1").
-                then().statusCode(HttpStatus.SC_FORBIDDEN);
-    }
-
-    @Test
-    public void testGetOtherProfileAnonymous() {
-        when().get("/users/1/profile").
                 then().statusCode(HttpStatus.SC_FORBIDDEN);
     }
 


### PR DESCRIPTION
The UserRestController is now split into 3 seperate controllers for CurrentUsers, Profiles en Users.

Also removed dedicated /profile GET endpoints since these are already include in the /users responses. 

Due to some PreAuthorize optimizations, I had to externalize the AccessDeniedExceptionHandler. This is actually a good thing, since it reduces code duplication. 

Fixes #77 