### PR TITLE
Enable CSRF Protection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     compile("org.springframework.boot:spring-boot-starter-web")
     compile("org.springframework.boot:spring-boot-starter-mail")
     compile("org.springframework.boot:spring-boot-starter-thymeleaf")
+    compile("com.allanditzel:spring-security-csrf-token-filter:1.1")
     runtime("org.hsqldb:hsqldb")
     runtime("org.postgresql:postgresql:9.4-1203-jdbc42")
     compile("com.google.guava:guava:19.0")

--- a/src/main/java/ch/wisv/areafiftylan/controller/AuthenticationController.java
+++ b/src/main/java/ch/wisv/areafiftylan/controller/AuthenticationController.java
@@ -53,6 +53,11 @@ public class AuthenticationController {
         return new ModelAndView("loginForm");
     }
 
+    @RequestMapping(value = "/token", method = RequestMethod.GET)
+    public ResponseEntity<?> checkSession(HttpServletRequest request) {
+        return createResponseEntity(HttpStatus.OK, "Here's your token!", request);
+    }
+
     /**
      * This method requests a passwordResetToken and sends it to the user. With this token, the user can reset his
      * password.

--- a/src/main/java/ch/wisv/areafiftylan/security/SecurityConfiguration.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/SecurityConfiguration.java
@@ -12,9 +12,6 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.csrf.CsrfFilter;
-import org.springframework.security.web.csrf.CsrfToken;
-
-import static ch.wisv.areafiftylan.util.ResponseEntityBuilder.createLoginResponseString;
 
 @Configuration
 @EnableGlobalMethodSecurity(prePostEnabled = true)
@@ -46,22 +43,19 @@ class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .failureUrl("/login?error")
                 .usernameParameter("username")
                 .permitAll()
-                //@formatter:on
-                .successHandler((request, response, authentication) -> {
-                    String token = ((CsrfToken) request.getAttribute(CsrfToken.class.getName())).getToken();
-                    response.getWriter().write(createLoginResponseString(token));
-                    response.getWriter().flush();
-                })
-                //@formatter:off
-                .and()
+            .and()
                 .logout()
                 .logoutUrl("/logout")
                 .logoutSuccessUrl("/")
                 .permitAll()
-                .and().authorizeRequests()
+            .and().authorizeRequests()
                 .antMatchers("/mail").hasAuthority("ADMIN")
                 .anyRequest().permitAll();
         //                .anyRequest().authenticated();
+        //@formatter:on
+
+        // This is the filter that adds the CSRF Token to the header. CSRF is enabled by default in Spring, this just
+        // copies the content to the X-CSRF-TOKEN header field.
         http.addFilterAfter(new CsrfTokenResponseHeaderBindingFilter(), CsrfFilter.class);
     }
 

--- a/src/main/java/ch/wisv/areafiftylan/security/SecurityConfiguration.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/SecurityConfiguration.java
@@ -1,5 +1,6 @@
 package ch.wisv.areafiftylan.security;
 
+import com.allanditzel.springframework.security.web.csrf.CsrfTokenResponseHeaderBindingFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +11,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.csrf.CsrfFilter;
 
 @Configuration
 @EnableGlobalMethodSecurity(prePostEnabled = true)
@@ -44,12 +46,10 @@ class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .logoutSuccessUrl("/")
                 .permitAll()
             .and().authorizeRequests()
-                .antMatchers("/login*").permitAll()
                 .antMatchers("/mail").hasAuthority("ADMIN")
-                .antMatchers("/teams").authenticated()
                 .anyRequest().permitAll();
 //                .anyRequest().authenticated();
-        http.csrf().disable(); //FIXME
+        http.addFilterAfter(new CsrfTokenResponseHeaderBindingFilter(), CsrfFilter.class);
     }
 
     @Override

--- a/src/main/java/ch/wisv/areafiftylan/util/ResponseEntityBuilder.java
+++ b/src/main/java/ch/wisv/areafiftylan/util/ResponseEntityBuilder.java
@@ -1,13 +1,10 @@
 package ch.wisv.areafiftylan.util;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -48,21 +45,6 @@ public class ResponseEntityBuilder {
     public static ResponseEntity<?> createResponseEntity(HttpStatus httpStatus, HttpHeaders httpHeaders,
                                                          String message) {
         return createResponseEntity(httpStatus, httpHeaders, message, null);
-    }
-
-    public static String createLoginResponseString(String token) {
-        Map<String, Object> responseBody = new HashMap<>();
-        responseBody.put("status", HttpStatus.OK);
-        responseBody.put("timestamp", LocalDateTime.now().toString());
-        responseBody.put("message", "Successfully logged in");
-        responseBody.put("_csrf", token);
-        ObjectMapper mapper = new ObjectMapper();
-        try {
-            return mapper.writeValueAsString(responseBody);
-        } catch (JsonProcessingException ignored) {
-        }
-        return "Useful error";
-
     }
 }
 

--- a/src/main/java/ch/wisv/areafiftylan/util/ResponseEntityBuilder.java
+++ b/src/main/java/ch/wisv/areafiftylan/util/ResponseEntityBuilder.java
@@ -1,10 +1,13 @@
 package ch.wisv.areafiftylan.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -45,6 +48,21 @@ public class ResponseEntityBuilder {
     public static ResponseEntity<?> createResponseEntity(HttpStatus httpStatus, HttpHeaders httpHeaders,
                                                          String message) {
         return createResponseEntity(httpStatus, httpHeaders, message, null);
+    }
+
+    public static String createLoginResponseString(String token) {
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("status", HttpStatus.OK);
+        responseBody.put("timestamp", LocalDateTime.now().toString());
+        responseBody.put("message", "Successfully logged in");
+        responseBody.put("_csrf", token);
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.writeValueAsString(responseBody);
+        } catch (JsonProcessingException ignored) {
+        }
+        return "Useful error";
+
     }
 }
 

--- a/src/main/resources/config/application-test.properties
+++ b/src/main/resources/config/application-test.properties
@@ -23,5 +23,3 @@ spring.thymeleaf.suffix=.html
 spring.thymeleaf.mode=HTML5
 spring.thymeleaf.encoding=UTF-8
 spring.thymeleaf.content-type=text/html
-
-security.basic.enabled=true

--- a/src/main/resources/config/application-test.properties
+++ b/src/main/resources/config/application-test.properties
@@ -4,7 +4,7 @@ spring.datasource.url=jdbc:hsqldb:mem:a5l
 spring.datasource.username=sa
 spring.datasource.password=
 spring.data.jpa.repositories.enabled=true
-spring.jpa.show-sql=true
+spring.jpa.show-sql=false
 spring.jpa.database-platform=org.hibernate.dialect.HSQLDialect
 spring.jpa.database=HSQL
 spring.jpa.generate-ddl=true
@@ -23,3 +23,5 @@ spring.thymeleaf.suffix=.html
 spring.thymeleaf.mode=HTML5
 spring.thymeleaf.encoding=UTF-8
 spring.thymeleaf.content-type=text/html
+
+security.basic.enabled=true

--- a/src/main/resources/config/application.properties.sample
+++ b/src/main/resources/config/application.properties.sample
@@ -4,8 +4,6 @@ security.user.password =
 #Default Property file, which is committed in Git
 spring.mail.host=
 spring.mail.port=
-spring.mail.username=
-spring.mail.password=
 
 # THYMELEAF (ThymeleafAutoConfiguration)
 spring.thymeleaf.check-template-location=true

--- a/src/test/java/ch/wisv/areafiftylan/TeamRestIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/TeamRestIntegrationTest.java
@@ -4,6 +4,7 @@ import ch.wisv.areafiftylan.model.Team;
 import ch.wisv.areafiftylan.model.User;
 import ch.wisv.areafiftylan.model.util.Gender;
 import ch.wisv.areafiftylan.service.repository.TeamRepository;
+import ch.wisv.areafiftylan.util.SessionData;
 import com.jayway.restassured.http.ContentType;
 import com.jayway.restassured.response.Response;
 import org.apache.http.HttpStatus;
@@ -11,25 +12,17 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.boot.test.WebIntegrationTest;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static com.jayway.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
 
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = ApplicationTest.class)
-@WebIntegrationTest("server.port=0")
-@ActiveProfiles("test")
 public class TeamRestIntegrationTest extends IntegrationTest {
 
     protected User teamCaptain;
@@ -55,6 +48,7 @@ public class TeamRestIntegrationTest extends IntegrationTest {
 
     @After
     public void teamTestsCleanup() {
+        logout();
         teamRepository.deleteAll();
         userRepository.delete(teamCaptain);
     }
@@ -63,19 +57,23 @@ public class TeamRestIntegrationTest extends IntegrationTest {
     public void testCreateTeam_nonAdmin_correct() {
         team1.put("captainUsername", teamCaptain.getUsername());
 
+        SessionData login = login("captain", "password");
+
         //@formatter:off
         Integer teamId =
-                given().
-                        auth().form("captain", "password", formAuthConfig).
-                        when().
-                        content(team1).contentType(ContentType.JSON).post("/teams").
-                        then().log().all().
-                        statusCode(HttpStatus.SC_CREATED).
-                        header("Location", containsString("/teams/")).
-                        body("object.teamName", equalTo(team1.get("teamName"))).
-                        body("object.captain.profile.displayName", equalTo(teamCaptain.getProfile().getDisplayName())).
-                        body("object.members", hasSize(1)).
-                        extract().response().path("object.id");
+            given().
+                filter(sessionFilter).
+                header(login.getCsrfHeader()).
+            when().
+                content(team1).contentType(ContentType.JSON).
+                post("/teams").
+            then().
+                statusCode(HttpStatus.SC_CREATED).
+                header("Location", containsString("/teams/")).
+                body("object.teamName", equalTo(team1.get("teamName"))).
+                body("object.captain.profile.displayName", equalTo(teamCaptain.getProfile().getDisplayName())).
+                body("object.members", hasSize(1)).
+            extract().response().path("object.id");
         //@formatter:on
 
         Team team = teamRepository.getOne(new Long(teamId));
@@ -86,13 +84,17 @@ public class TeamRestIntegrationTest extends IntegrationTest {
     public void testCreateTeam_nonAdmin_differentCaptain() {
         team1.put("captainUsername", user.getUsername());
 
+        SessionData login = login("captain", "password");
+
         //@formatter:off
         given().
-                auth().form("captain", "password", formAuthConfig).
-                when().
-                content(team1).contentType(ContentType.JSON).post("/teams").
-                then().log().ifValidationFails().
-                statusCode(HttpStatus.SC_BAD_REQUEST);
+            filter(sessionFilter).
+            header(login.getCsrfHeader()).
+        when().
+            content(team1).contentType(ContentType.JSON).
+            post("/teams").
+        then().
+            statusCode(HttpStatus.SC_BAD_REQUEST);
         //@formatter:on
     }
 
@@ -100,17 +102,21 @@ public class TeamRestIntegrationTest extends IntegrationTest {
     public void testCreateTeam_Admin_differentCaptain() {
         team1.put("captainUsername", teamCaptain.getUsername());
 
+        SessionData login = login("admin", "password");
+
         //@formatter:off
         given().
-                auth().form("admin", "password", formAuthConfig).
-                when().
-                content(team1).contentType(ContentType.JSON).post("/teams").
-                then().log().all().
-                statusCode(HttpStatus.SC_CREATED).
-                header("Location", containsString("/teams/")).
-                body("object.teamName", equalTo(team1.get("teamName"))).
-                body("object.captain.profile.displayName", equalTo(teamCaptain.getProfile().getDisplayName())).
-                body("object.members", hasSize(1));
+            filter(sessionFilter).
+            header(login.getCsrfHeader()).
+        when().
+            content(team1).contentType(ContentType.JSON).
+            post("/teams").
+        then().
+            statusCode(HttpStatus.SC_CREATED).
+            header("Location", containsString("/teams/")).
+            body("object.teamName", equalTo(team1.get("teamName"))).
+            body("object.captain.profile.displayName", equalTo(teamCaptain.getProfile().getDisplayName())).
+            body("object.members", hasSize(1));
         //@formatter:on
     }
 
@@ -118,26 +124,36 @@ public class TeamRestIntegrationTest extends IntegrationTest {
     public void testCreateTeam_nonAdmin_duplicateTeamName() {
         team1.put("captainUsername", teamCaptain.getUsername());
 
+        SessionData login = login("captain", "password");
+
         //@formatter:off
         given().
-                auth().form("captain", "password", formAuthConfig).
-                when().
-                content(team1).contentType(ContentType.JSON).post("/teams").
-                then().log().all().
-                statusCode(HttpStatus.SC_CREATED).
-                header("Location", containsString("/teams/")).
-                body("object.teamName", equalTo(team1.get("teamName"))).
-                body("object.captain.profile.displayName", equalTo(teamCaptain.getProfile().getDisplayName())).
-                body("object.members.profile.displayName", hasItem(teamCaptain.getProfile().getDisplayName()));
+            filter(sessionFilter).
+            header(login.getCsrfHeader()).
+        when().
+            content(team1).contentType(ContentType.JSON).
+            post("/teams").
+        then().
+            statusCode(HttpStatus.SC_CREATED).
+            header("Location", containsString("/teams/")).
+            body("object.teamName", equalTo(team1.get("teamName"))).
+            body("object.captain.profile.displayName", equalTo(teamCaptain.getProfile().getDisplayName())).
+            body("object.members.profile.displayName", hasItem(teamCaptain.getProfile().getDisplayName()));
         //@formatter:on
+
+        logout();
 
         team1.put("captainUsername", user.getUsername());
 
+        SessionData login2 = login("user", "password");
+
         //@formatter:off
         given().
-            auth().form("user", "password", formAuthConfig).
+            filter(sessionFilter).
+            header(login2.getCsrfHeader()).
         when().
-            content(team1).contentType(ContentType.JSON).post("/teams").
+            content(team1).contentType(ContentType.JSON).
+            post("/teams").
         then().log().ifValidationFails().
             statusCode(HttpStatus.SC_CONFLICT);
         //@formatter:on
@@ -175,29 +191,57 @@ public class TeamRestIntegrationTest extends IntegrationTest {
     }
 
     private void addUserAsCaptain(String location, User user) {
-        given().
-                auth().form("captain", "password", springFormConfig).
-                when().
-                content(user.getUsername()).post(location).
-                then().log().ifValidationFails().statusCode(HttpStatus.SC_OK);
+        SessionData sessionData = login("captain", "password");
+
+        //@formatter:off
+        given().log().all().
+            filter(sessionFilter).
+            header(sessionData.getCsrfHeader()).
+        when().
+            content(user.getUsername()).post(location).
+        then().
+            statusCode(HttpStatus.SC_OK);
+        //@formatter:on
+
+        logout();
     }
 
     private String createTeamWithCaptain() {
-        team1.put("captainUsername", teamCaptain.getUsername());
+        SessionData sessionData = login("captain", "password");
 
-        return given().
-                auth().form("captain", "password", springFormConfig).log().all().
-                when().
-                content(team1).contentType(ContentType.JSON).post("/teams").
-                then().log().all().extract().response().header("Location");
+        team1.put("captainUsername", teamCaptain.getUsername());
+        //        team1.put("_csrf", csrfToken.getToken());
+
+        //@formatter:off
+        Response response =
+            given().
+                    header(sessionData.getCsrfHeader()).
+//                        cookie(sessionData.getCookie()).
+                    filter(sessionFilter).
+            when().
+                content(team1).contentType(ContentType.JSON).
+                post("/teams").
+            then().
+                extract().response();
+        //@formatter:on
+
+
+        logout();
+        return response.header("Location");
     }
 
     private Response getTeam(String location, String user, String password) {
-        return given().
-                auth().form(user, password, formAuthConfig).
-                when().
+        SessionData login = login(user, password);
+
+        //@formatter:off
+        return
+            given().
+                filter(sessionFilter).
+                header(login.getCsrfHeader()).
+            when().
                 get(location).
-                then().log().all().extract().response();
+            then().extract().response();
+        //@formatter:on
     }
 
     @Test
@@ -206,18 +250,28 @@ public class TeamRestIntegrationTest extends IntegrationTest {
         //@formatter:off
         String location = createTeamWithCaptain();
 
+        SessionData login = login("admin", "password");
+
+        //@formatter:off
         given().
-            auth().form("admin", "password", formAuthConfig).
+            filter(sessionFilter).
+            header(login.getCsrfHeader()).
         when().
             content(user.getUsername()).post(location).
         then().log().ifValidationFails()
             .statusCode(HttpStatus.SC_OK);
 
+        logout();
+
+        SessionData login2 = login("admin", "password");
+
+        //@formatter:off
         given().
-            auth().form("admin", "password", formAuthConfig).
+            filter(sessionFilter).
+            header(login.getCsrfHeader()).
         when().
             get(location).
-        then().log().ifValidationFails().
+        then().
             statusCode(HttpStatus.SC_OK).
             body("members.profile.displayName", hasItems(
                     teamCaptain.getProfile().getDisplayName(),
@@ -235,8 +289,12 @@ public class TeamRestIntegrationTest extends IntegrationTest {
 
         addUserAsCaptain(location, user);
 
+        SessionData login = login("captain", "password");
+
+        //@formatter:off
         given().
-            auth().form("captain", "password", formAuthConfig).log().all().
+            filter(sessionFilter).
+            header(login.getCsrfHeader()).
         when().
             get(location).
         then().log().ifValidationFails().
@@ -257,8 +315,12 @@ public class TeamRestIntegrationTest extends IntegrationTest {
 
         addUserAsCaptain(location, user);
 
+        SessionData login = login("user", "password");
+
+        //@formatter:off
         given().
-            auth().form("user", "password", formAuthConfig).
+            filter(sessionFilter).
+            header(login.getCsrfHeader()).
         when().
             content(admin.getUsername()).post(location).
         then().log().ifValidationFails()
@@ -273,8 +335,12 @@ public class TeamRestIntegrationTest extends IntegrationTest {
         //@formatter:off
         String location = createTeamWithCaptain();
 
+        SessionData login = login("user", "password");
+
+        //@formatter:off
         given().
-            auth().form("user", "password", formAuthConfig).
+            filter(sessionFilter).
+            header(login.getCsrfHeader()).
         when().
             content(user.getUsername()).post(location).
         then().log().ifValidationFails()
@@ -286,9 +352,12 @@ public class TeamRestIntegrationTest extends IntegrationTest {
     public void testAddMember_captain() {
         String location = createTeamWithCaptain();
 
+        SessionData login = login("captain", "password");
+
         //@formatter:off
         given().
-            auth().form("captain", "password", formAuthConfig).
+            filter(sessionFilter).
+            header(login.getCsrfHeader()).
         when().
             content(teamCaptain.getUsername()).post(location).
         then().log().all()
@@ -300,16 +369,24 @@ public class TeamRestIntegrationTest extends IntegrationTest {
     public void testAddMember_duplicate() {
         String location = createTeamWithCaptain();
 
+        SessionData login = login("captain", "password");
+
         //@formatter:off
         given().
-            auth().form("captain", "password", formAuthConfig).
+            filter(sessionFilter).
+            header(login.getCsrfHeader()).
         when().
             content(user.getUsername()).post(location).
         then().log().all()
             .statusCode(HttpStatus.SC_OK);
 
+        logout();
+
+        SessionData login2 = login("captain", "password");
+
         given().
-            auth().form("captain", "password", formAuthConfig).
+            filter(sessionFilter).
+            header(login2.getCsrfHeader()).
         when().
             content(user.getUsername()).post(location).
         then().log().all()
@@ -323,9 +400,12 @@ public class TeamRestIntegrationTest extends IntegrationTest {
 
         addUserAsCaptain(location, user);
 
+        SessionData login = login("captain", "password");
+
         //@formatter:off
         given().
-            auth().form("captain", "password", formAuthConfig).
+            filter(sessionFilter).
+            header(login.getCsrfHeader()).
         when().
             content(user.getUsername()).delete(location + "/members").
         then().log().all()
@@ -339,9 +419,12 @@ public class TeamRestIntegrationTest extends IntegrationTest {
 
         addUserAsCaptain(location, user);
 
+        SessionData login = login("captain", "password");
+
         //@formatter:off
         given().
-            auth().form("captain", "password", formAuthConfig).
+            filter(sessionFilter).
+            header(login.getCsrfHeader()).
         when().
             content(user.getUsername()).delete(location + "/members").
         then().log().all()
@@ -355,9 +438,12 @@ public class TeamRestIntegrationTest extends IntegrationTest {
 
         addUserAsCaptain(location, user);
 
+        SessionData login = login("user", "password");
+
         //@formatter:off
         given().
-            auth().form("user", "password", formAuthConfig).
+            filter(sessionFilter).
+            header(login.getCsrfHeader()).
         when().
             content(user.getUsername()).delete(location + "/members").
         then().log().all()
@@ -371,9 +457,12 @@ public class TeamRestIntegrationTest extends IntegrationTest {
 
         addUserAsCaptain(location, admin);
 
+        SessionData login = login("user", "password");
+
         //@formatter:off
         given().
-            auth().form("user", "password", formAuthConfig).
+            filter(sessionFilter).
+            header(login.getCsrfHeader()).
         when().
             content(admin.getUsername()).delete(location + "/members").
         then().log().all()

--- a/src/test/java/ch/wisv/areafiftylan/TeamRestIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/TeamRestIntegrationTest.java
@@ -144,21 +144,21 @@ public class TeamRestIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    public void getTeamAsAdmin(){
+    public void getTeamAsAdmin() {
         Response team = getTeam(createTeamWithCaptain(), "admin", "password");
 
         team.then().statusCode(HttpStatus.SC_OK);
     }
 
     @Test
-    public void getTeamAsCaptain(){
+    public void getTeamAsCaptain() {
         Response team = getTeam(createTeamWithCaptain(), "captain", "password");
 
         team.then().statusCode(HttpStatus.SC_OK);
     }
 
     @Test
-    public void getTeamAsMember(){
+    public void getTeamAsMember() {
         String location = createTeamWithCaptain();
         addUserAsCaptain(location, user);
         Response team = getTeam(location, "user", "password");
@@ -167,7 +167,7 @@ public class TeamRestIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    public void getTeamAsUser(){
+    public void getTeamAsUser() {
         String location = createTeamWithCaptain();
         Response team = getTeam(location, "user", "password");
 
@@ -176,7 +176,7 @@ public class TeamRestIntegrationTest extends IntegrationTest {
 
     private void addUserAsCaptain(String location, User user) {
         given().
-                auth().form("captain", "password", formAuthConfig).
+                auth().form("captain", "password", springFormConfig).
                 when().
                 content(user.getUsername()).post(location).
                 then().log().ifValidationFails().statusCode(HttpStatus.SC_OK);
@@ -186,7 +186,7 @@ public class TeamRestIntegrationTest extends IntegrationTest {
         team1.put("captainUsername", teamCaptain.getUsername());
 
         return given().
-                auth().form("captain", "password", formAuthConfig).
+                auth().form("captain", "password", springFormConfig).log().all().
                 when().
                 content(team1).contentType(ContentType.JSON).post("/teams").
                 then().log().all().extract().response().header("Location");
@@ -236,7 +236,7 @@ public class TeamRestIntegrationTest extends IntegrationTest {
         addUserAsCaptain(location, user);
 
         given().
-            auth().form("captain", "password", formAuthConfig).
+            auth().form("captain", "password", formAuthConfig).log().all().
         when().
             get(location).
         then().log().ifValidationFails().
@@ -318,7 +318,7 @@ public class TeamRestIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    public void testRemoveMember_captain(){
+    public void testRemoveMember_captain() {
         String location = createTeamWithCaptain();
 
         addUserAsCaptain(location, user);
@@ -334,7 +334,7 @@ public class TeamRestIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    public void testRemoveMember_admin(){
+    public void testRemoveMember_admin() {
         String location = createTeamWithCaptain();
 
         addUserAsCaptain(location, user);
@@ -350,7 +350,7 @@ public class TeamRestIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    public void testRemoveMember_member(){
+    public void testRemoveMember_member() {
         String location = createTeamWithCaptain();
 
         addUserAsCaptain(location, user);
@@ -366,7 +366,7 @@ public class TeamRestIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    public void testRemoveMember_user(){
+    public void testRemoveMember_user() {
         String location = createTeamWithCaptain();
 
         addUserAsCaptain(location, admin);

--- a/src/test/java/ch/wisv/areafiftylan/util/SessionData.java
+++ b/src/test/java/ch/wisv/areafiftylan/util/SessionData.java
@@ -1,0 +1,31 @@
+package ch.wisv.areafiftylan.util;
+
+import com.jayway.restassured.response.Cookie;
+import com.jayway.restassured.response.Header;
+
+public class SessionData {
+    Header token;
+    Cookie cookie;
+
+    public SessionData(String token, String cookie) {
+        this.token = new Header("X-CSRF-TOKEN", token);
+        this.cookie = new Cookie.Builder("JSESSIONID", cookie).build();
+    }
+
+    public Header getCsrfHeader() {
+        return token;
+    }
+
+    public String getToken() {
+        return token.getValue();
+    }
+
+    public Cookie getCookie() {
+        return cookie;
+    }
+
+    public String getSessionId() {
+        return cookie.getValue();
+    }
+
+}


### PR DESCRIPTION
This enables CSRF protection. This means that every POST requests needs a CSRF token in the header at X-CSRF-TOKEN or your request will be denied. 

You can get a token from a GET on /login or /token

Fixes #73

Also, FUCK REST-Assured. Had to rewrite all the tests. 

/cc @stijncr If you manage to find time to write tests, make sure you do it in this new format.