### PR TITLE
Add Order Id to response

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/model/Order.java
+++ b/src/main/java/ch/wisv/areafiftylan/model/Order.java
@@ -16,6 +16,7 @@ public class Order {
 
     @Id
     @GeneratedValue
+    @JsonView(View.OrderOverview.class)
     Long id;
 
     @OneToMany(cascade = CascadeType.MERGE, targetEntity = Ticket.class, fetch = FetchType.EAGER)

--- a/src/main/java/ch/wisv/areafiftylan/model/Order.java
+++ b/src/main/java/ch/wisv/areafiftylan/model/Order.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.annotation.JsonView;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 
@@ -21,7 +21,7 @@ public class Order {
 
     @OneToMany(cascade = CascadeType.MERGE, targetEntity = Ticket.class, fetch = FetchType.EAGER)
     @JsonView(View.OrderOverview.class)
-    Collection<Ticket> tickets;
+    Set<Ticket> tickets;
 
     @JsonView(View.OrderOverview.class)
     OrderStatus status;
@@ -58,7 +58,7 @@ public class Order {
         return id;
     }
 
-    public Collection<Ticket> getTickets() {
+    public Set<Ticket> getTickets() {
         return tickets;
     }
 

--- a/src/main/resources/config/application-test.properties
+++ b/src/main/resources/config/application-test.properties
@@ -24,6 +24,8 @@ spring.thymeleaf.mode=HTML5
 spring.thymeleaf.encoding=UTF-8
 spring.thymeleaf.content-type=text/html
 
+server.context-path=/
+
 ##AREA FIFTYLAN SETTINGS
 
 a5l.paymentReturnUrl=https://areafiftylan.nl/ordersuccess

--- a/src/test/java/ch/wisv/areafiftylan/OrderRestIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/OrderRestIntegrationTest.java
@@ -230,7 +230,7 @@ public class OrderRestIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    public void testCreateSingleOrderMissingTypeParameter(){
+    public void testCreateSingleOrderMissingTypeParameter() {
         Map<String, String> order = new HashMap<>();
         order.put("pickupService", "true");
         order.put("chMember", "false");
@@ -248,7 +248,7 @@ public class OrderRestIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    public void testCreateSingleOrderMissingChParameter(){
+    public void testCreateSingleOrderMissingChParameter() {
         Map<String, String> order = new HashMap<>();
         order.put("type", TicketType.EARLY_FULL.toString());
         order.put("pickupService", "true");
@@ -307,7 +307,7 @@ public class OrderRestIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    public void testGetOrder_Anon(){
+    public void testGetOrder_Anon() {
         String location = createOrderAndReturnLocation();
         logout();
 
@@ -339,10 +339,10 @@ public class OrderRestIntegrationTest extends IntegrationTest {
             body("status", is("CREATING")).
             body("reference", is(nullValue())).
             body("user.username", is("user")).
+            body("tickets", hasSize(1)).
             body("tickets.type", hasItem(is("EARLY_FULL"))).
             body("tickets.pickupService", hasItem(is(false))).
             body("amount",equalTo(35.00F));
-
         //@formatter:on
     }
 
@@ -554,7 +554,7 @@ public class OrderRestIntegrationTest extends IntegrationTest {
 
     @Test
     public void testAddToOrderUnavailableTicket() {
-        for (int i = 0; i < TicketType.EARLY_FULL.getLimit() -1; i++) {
+        for (int i = 0; i < TicketType.EARLY_FULL.getLimit() - 1; i++) {
             ticketRepository.save(new Ticket(user, TicketType.EARLY_FULL, false, false));
         }
 


### PR DESCRIPTION
The Id is needed in the frontend to post. This is easier than the location, because the iron-ajax only needs the id and not the full location.