### PR TITLE
Remove redirects on login

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/security/RESTAuthenticationEntryPoint.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/RESTAuthenticationEntryPoint.java
@@ -1,0 +1,23 @@
+package ch.wisv.areafiftylan.security;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * This class overrides Springs default behaviour for unauthorized requests. Whenever a user is supposed to be logged in
+ * and the controller doesn't handle it, it will return a 401 Status message
+ */
+@Component
+public class RESTAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/ch/wisv/areafiftylan/security/RESTAuthenticationFailureHandler.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/RESTAuthenticationFailureHandler.java
@@ -1,0 +1,22 @@
+package ch.wisv.areafiftylan.security;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * When a login request fails, we just invoke the default failure handler.
+ */
+@Component
+public class RESTAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+        super.onAuthenticationFailure(request, response, exception);
+    }
+}

--- a/src/main/java/ch/wisv/areafiftylan/security/RESTAuthenticationSuccessHandler.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/RESTAuthenticationSuccessHandler.java
@@ -1,0 +1,22 @@
+package ch.wisv.areafiftylan.security;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * With a successful login request, this simply returns a 200 OK, instead of going into a redirect flow
+ */
+@Component
+public class RESTAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        clearAuthenticationAttributes(request);
+    }
+}


### PR DESCRIPTION
Due to the way the app is running behind an Apache server, internal redirects fail miserably with mixed content errors. This fixes that behaviour by eliminating redirects. Instead, it returns a 200 OK for successful logins, and a 401 for unauthenticated requests and failed login attempts. 