### PR TITLE
Enable manual Order status updates

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/controller/OrderRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/controller/OrderRestController.java
@@ -158,10 +158,20 @@ public class OrderRestController {
 
     @RequestMapping(value = "/orders/status", method = { RequestMethod.GET,
             RequestMethod.POST }, params = "testByMollie")
-    public ResponseEntity<?> handleMollieTestCall(){
+    public ResponseEntity<?> handleMollieTestCall() {
         return createResponseEntity(HttpStatus.OK, "Mollie webhook available");
     }
 
+    /**
+     * This call allows for manual updating of an order status. It updates the status directly at the paymentprovider,
+     * so the status is always current
+     *
+     * @param orderId OrderId of the Order to be updated
+     *
+     * @return The Order with an up-to-date status
+     */
+    @PreAuthorize("@currentUserServiceImpl.canAccessOrder(principal, #orderId)")
+    @JsonView(View.OrderOverview.class)
     @RequestMapping(value = "/orders/{orderId}/status", method = RequestMethod.GET)
     public ResponseEntity<?> updateOrderStatusManual(@PathVariable long orderId) {
         Order order = orderService.updateOrderStatus(orderId);
@@ -170,6 +180,7 @@ public class OrderRestController {
 
     /**
      * This method returns an overview of available tickets with some additional information
+     *
      * @return A collection of all TicketTypes and their availability
      */
     @RequestMapping(value = "/tickets/available", method = RequestMethod.GET)

--- a/src/main/java/ch/wisv/areafiftylan/controller/OrderRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/controller/OrderRestController.java
@@ -162,6 +162,12 @@ public class OrderRestController {
         return createResponseEntity(HttpStatus.OK, "Mollie webhook available");
     }
 
+    @RequestMapping(value = "/orders/{orderId}/status", method = RequestMethod.GET)
+    public ResponseEntity<?> updateOrderStatusManual(@PathVariable long orderId) {
+        Order order = orderService.updateOrderStatus(orderId);
+        return createResponseEntity(HttpStatus.OK, "Order status updated", order);
+    }
+
     /**
      * This method returns an overview of available tickets with some additional information
      * @return A collection of all TicketTypes and their availability

--- a/src/main/java/ch/wisv/areafiftylan/model/util/OrderStatus.java
+++ b/src/main/java/ch/wisv/areafiftylan/model/util/OrderStatus.java
@@ -4,5 +4,5 @@ package ch.wisv.areafiftylan.model.util;
  * Created by sille on 22-12-15.
  */
 public enum OrderStatus {
-    CREATING, WAITING, PAID, EXPIRED
+    CREATING, WAITING, PAID, EXPIRED, CANCELLED
 }

--- a/src/main/java/ch/wisv/areafiftylan/service/MolliePaymentService.java
+++ b/src/main/java/ch/wisv/areafiftylan/service/MolliePaymentService.java
@@ -51,7 +51,7 @@ public class MolliePaymentService implements PaymentService {
         metadata.put("A5LId", order.getId());
 
         CreatePayment payment =
-                new CreatePayment(method, (double) order.getAmount(), "Area FiftyLAN Ticket", returnUrl, metadata);
+                new CreatePayment(method, (double) order.getAmount(), "Area FiftyLAN Ticket", returnUrl + "?order=" + order.getId(), metadata);
 
         //First try is for IOExceptions coming from the Mollie Client.
         try {
@@ -97,8 +97,12 @@ public class MolliePaymentService implements PaymentService {
                 // There are a couple of possible statuses. Enum would have been nice. We select a couple of relevant
                 // statuses to translate to our own status.
                 switch (molliePaymentStatus.getData().getStatus()) {
+                    case "pending": {
+                        order.setStatus(OrderStatus.WAITING);
+                        break;
+                    }
                     case "cancelled": {
-                        order.setStatus(OrderStatus.EXPIRED);
+                        order.setStatus(OrderStatus.CANCELLED);
                         break;
                     }
                     case "expired": {

--- a/src/main/java/ch/wisv/areafiftylan/service/OrderServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/service/OrderServiceImpl.java
@@ -46,7 +46,7 @@ public class OrderServiceImpl implements OrderService {
 
     @Override
     public Order getOrderById(Long id) {
-        return orderRepository.findOne(id);
+        return orderRepository.findById(id).orElseThrow(() -> new OrderNotFoundException("Order " + id + " not found"));
     }
 
     @Override
@@ -71,7 +71,7 @@ public class OrderServiceImpl implements OrderService {
         User user = userService.getUserById(userId);
 
         for (Order order : orderRepository.findAllByUserUsername(user.getUsername())) {
-            if(order.getStatus().equals(OrderStatus.CREATING)){
+            if (order.getStatus().equals(OrderStatus.CREATING)) {
                 throw new IllegalStateException("User already created a new Order: " + order.getId());
             }
         }
@@ -138,7 +138,8 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
-    public synchronized Ticket requestTicketOfType(TicketType type, User owner, boolean pickupService, boolean chMember) {
+    public synchronized Ticket requestTicketOfType(TicketType type, User owner, boolean pickupService,
+                                                   boolean chMember) {
         if (ticketRepository.countByType(type) >= type.getLimit()) {
             throw new TicketUnavailableException(type);
         } else {
@@ -166,7 +167,7 @@ public class OrderServiceImpl implements OrderService {
 
     @Override
     public String requestPayment(Long orderId) {
-        Order order = orderRepository.findOne(orderId);
+        Order order = getOrderById(orderId);
         return paymentService.registerOrder(order);
     }
 
@@ -196,7 +197,7 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
-    public void expireOrder(Order o){
+    public void expireOrder(Order o) {
         orderRepository.delete(o);
         ExpiredOrder eo = new ExpiredOrder(o);
         expiredOrderRepository.save(eo);

--- a/src/main/java/ch/wisv/areafiftylan/service/TaskScheduler.java
+++ b/src/main/java/ch/wisv/areafiftylan/service/TaskScheduler.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 
 /**
  * Created by beer on 28-12-15.
- *
+ * <p>
  * Class with all scheduled tasks
  */
 @Component
@@ -34,7 +34,7 @@ public class TaskScheduler {
 
 
     @Scheduled(fixedRate = ORDER_EXPIRY_CHECK_INTERVAL_SECONDS * 1000)
-    public void ExpireOrders(){
+    public void ExpireOrders() {
         LocalDateTime expireBeforeDate = LocalDateTime.now().minusMinutes(ORDER_STAY_ALIVE_MINUTES);
 
         Collection<Order> allOrdersBeforeDate = orderRepository.findAllByCreationDateTimeBefore(expireBeforeDate);
@@ -45,6 +45,7 @@ public class TaskScheduler {
     }
 
     public static Predicate<Order> isExpired() {
-        return o -> o.getStatus().equals(OrderStatus.CREATING) || o.getStatus().equals(OrderStatus.EXPIRED);
+        return o -> o.getStatus().equals(OrderStatus.CREATING) || o.getStatus().equals(OrderStatus.EXPIRED) ||
+                o.getStatus().equals(OrderStatus.CANCELLED);
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/service/repository/OrderRepository.java
+++ b/src/main/java/ch/wisv/areafiftylan/service/repository/OrderRepository.java
@@ -10,6 +10,9 @@ import java.util.Optional;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    Optional<Order> findById(Long orderId);
+
     Collection<Order> findAllByCreationDateTimeBefore(LocalDateTime creationDate);
 
     Collection<Order> findAllByUserUsername(String username);


### PR DESCRIPTION
This PR adds a call to retreive the latest Order status at `/orders/{orderId}/status`. Next to that, the number of statusses has been updated to allow for non-pushable statusses coming from Mollie. The Order cleanup task has been expanded to include CANCELLED orders as well. 