### PR TITLE
Add end-point to return google maps key

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/controller/AuthenticationController.java
+++ b/src/main/java/ch/wisv/areafiftylan/controller/AuthenticationController.java
@@ -10,6 +10,7 @@ import ch.wisv.areafiftylan.service.UserService;
 import ch.wisv.areafiftylan.service.repository.PasswordResetTokenRepository;
 import ch.wisv.areafiftylan.service.repository.VerificationTokenRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -42,6 +43,8 @@ public class AuthenticationController {
     @Autowired
     PasswordResetTokenRepository passwordResetTokenRepository;
 
+    @Value("${a5l.googleMapsAPIkey}")
+    private String googleMapsKey;
 
     /**
      * This basic GET method for the /login endpoint returns a simple login form.
@@ -56,6 +59,11 @@ public class AuthenticationController {
     @RequestMapping(value = "/token", method = RequestMethod.GET)
     public ResponseEntity<?> checkSession() {
         return createResponseEntity(HttpStatus.OK, "Here's your token!");
+    }
+
+    @RequestMapping(value = "/googlemapskey", method = RequestMethod.GET)
+    public ResponseEntity<?> getGoogleMapsKey() {
+        return createResponseEntity(HttpStatus.OK, this.googleMapsKey);
     }
 
     /**

--- a/src/main/java/ch/wisv/areafiftylan/controller/AuthenticationController.java
+++ b/src/main/java/ch/wisv/areafiftylan/controller/AuthenticationController.java
@@ -10,7 +10,6 @@ import ch.wisv.areafiftylan.service.UserService;
 import ch.wisv.areafiftylan.service.repository.PasswordResetTokenRepository;
 import ch.wisv.areafiftylan.service.repository.VerificationTokenRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -43,9 +42,6 @@ public class AuthenticationController {
     @Autowired
     PasswordResetTokenRepository passwordResetTokenRepository;
 
-    @Value("${a5l.googleMapsAPIkey}")
-    private String googleMapsKey;
-
     /**
      * This basic GET method for the /login endpoint returns a simple login form.
      *
@@ -59,11 +55,6 @@ public class AuthenticationController {
     @RequestMapping(value = "/token", method = RequestMethod.GET)
     public ResponseEntity<?> checkSession() {
         return createResponseEntity(HttpStatus.OK, "Here's your token!");
-    }
-
-    @RequestMapping(value = "/googlemapskey", method = RequestMethod.GET)
-    public ResponseEntity<?> getGoogleMapsKey() {
-        return createResponseEntity(HttpStatus.OK, this.googleMapsKey);
     }
 
     /**

--- a/src/main/java/ch/wisv/areafiftylan/web/controller/WebPropertiesController.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/controller/WebPropertiesController.java
@@ -13,7 +13,7 @@ import static ch.wisv.areafiftylan.util.ResponseEntityBuilder.createResponseEnti
 @RequestMapping("/web/properties")
 public class WebPropertiesController {
 
-    @Value("${a5l.googleMapsAPIkey?:API_KEY}")
+    @Value("${a5l.googleMapsAPIkey:API_KEY}")
     private String googleMapsKey;
 
     @RequestMapping(value = "/googlemapskey", method = RequestMethod.GET)

--- a/src/main/java/ch/wisv/areafiftylan/web/controller/WebPropertiesController.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/controller/WebPropertiesController.java
@@ -1,0 +1,23 @@
+package ch.wisv.areafiftylan.web.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import static ch.wisv.areafiftylan.util.ResponseEntityBuilder.createResponseEntity;
+
+@RestController
+@RequestMapping("/web/properties")
+public class WebPropertiesController {
+
+    @Value("${a5l.googleMapsAPIkey}")
+    private String googleMapsKey = "API_KEY";
+
+    @RequestMapping(value = "/googlemapskey", method = RequestMethod.GET)
+    public ResponseEntity<?> getGoogleMapsKey() {
+        return createResponseEntity(HttpStatus.OK, this.googleMapsKey);
+    }
+}

--- a/src/main/java/ch/wisv/areafiftylan/web/controller/WebPropertiesController.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/controller/WebPropertiesController.java
@@ -13,8 +13,8 @@ import static ch.wisv.areafiftylan.util.ResponseEntityBuilder.createResponseEnti
 @RequestMapping("/web/properties")
 public class WebPropertiesController {
 
-    @Value("${a5l.googleMapsAPIkey}")
-    private String googleMapsKey = "API_KEY";
+    @Value("${a5l.googleMapsAPIkey?:API_KEY}")
+    private String googleMapsKey;
 
     @RequestMapping(value = "/googlemapskey", method = RequestMethod.GET)
     public ResponseEntity<?> getGoogleMapsKey() {

--- a/src/main/resources/config/application-test.properties
+++ b/src/main/resources/config/application-test.properties
@@ -32,4 +32,5 @@ a5l.mail.confirmUrl=https://areafiftylan.nl/#!/confirmRegistration
 a5l.user.resetUrl=https://areafiftylan.nl/#!/resetPassword
 a5l.mail.sender=LANcie <lancie@ch.tudelft.nl>
 a5l.orderLimit=5
+a5l.googleMapsAPIkey=API_KEY
 

--- a/src/main/resources/config/application-test.properties
+++ b/src/main/resources/config/application-test.properties
@@ -32,5 +32,4 @@ a5l.mail.confirmUrl=https://areafiftylan.nl/#!/confirmRegistration
 a5l.user.resetUrl=https://areafiftylan.nl/#!/resetPassword
 a5l.mail.sender=LANcie <lancie@ch.tudelft.nl>
 a5l.orderLimit=5
-a5l.googleMapsAPIkey=API_KEY
 

--- a/src/main/resources/config/application.properties.sample
+++ b/src/main/resources/config/application.properties.sample
@@ -48,4 +48,5 @@ a5l.user.resetUrl=https://areafiftylan.nl/#!/resetPassword
 # E-mail address used for sending e-mails
 a5l.mail.sender=LANcie <lancie@ch.tudelft.nl>
 a5l.orderLimit=5
-
+# API key for Google Maps
+a5l.googleMapsAPIkey=


### PR DESCRIPTION
In order to securely provide the Google Maps key, an extra end-point is added. This endpoint requires the property `a5l.googleMapsAPIkey` in the `application.properties` to be set.

You can generate your own key at https://console.developers.google.com/apis/credentials 
I have already generated a key for production. For local development, generate your own api key and set the domain to `localhost:5100`.