### PR TITLE
Changed open orders to List-based representation

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/controller/CurrentUserRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/controller/CurrentUserRestController.java
@@ -136,9 +136,9 @@ public class CurrentUserRestController {
      * @return The current open order, if any exist
      */
     @RequestMapping(value = "/orders/open", method = RequestMethod.GET)
-    public Order getOpenOrder(Authentication auth) {
+    public List<Order> getOpenOrder(Authentication auth) {
         UserDetails currentUser = (UserDetails) auth.getPrincipal();
-        return orderService.getOpenOrder(currentUser.getUsername());
+        return orderService.getOpenOrders(currentUser.getUsername());
     }
 
     @RequestMapping(value = "/seat", method = RequestMethod.GET)

--- a/src/main/java/ch/wisv/areafiftylan/controller/OrderRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/controller/OrderRestController.java
@@ -9,7 +9,6 @@ import ch.wisv.areafiftylan.model.Order;
 import ch.wisv.areafiftylan.model.User;
 import ch.wisv.areafiftylan.model.view.View;
 import ch.wisv.areafiftylan.service.OrderService;
-import ch.wisv.areafiftylan.service.UserService;
 import com.fasterxml.jackson.annotation.JsonView;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -30,14 +29,11 @@ import static ch.wisv.areafiftylan.util.ResponseEntityBuilder.createResponseEnti
 @RestController
 public class OrderRestController {
 
-    OrderService orderService;
-
-    UserService userService;
+    private OrderService orderService;
 
     @Autowired
-    public OrderRestController(OrderService orderService, UserService userService) {
+    public OrderRestController(OrderService orderService) {
         this.orderService = orderService;
-        this.userService = userService;
     }
 
     @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/ch/wisv/areafiftylan/service/OrderService.java
+++ b/src/main/java/ch/wisv/areafiftylan/service/OrderService.java
@@ -19,7 +19,7 @@ public interface OrderService {
 
     Collection<Order> findOrdersByUsername(String username);
 
-    Order getOpenOrder(String username);
+    List<Order> getOpenOrders(String username);
 
     /**
      * Create an order with at least one Ticket.

--- a/src/main/java/ch/wisv/areafiftylan/service/OrderServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/service/OrderServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 @Service
 public class OrderServiceImpl implements OrderService {
@@ -60,10 +61,12 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
-    public Order getOpenOrder(String username) {
+    public List<Order> getOpenOrders(String username) {
         Collection<Order> ordersByUsername = findOrdersByUsername(username);
-        return ordersByUsername.stream().filter(o -> o.getStatus().equals(OrderStatus.CREATING)).findFirst()
-                .orElseThrow(() -> new OrderNotFoundException("User has no open order"));
+
+        return ordersByUsername.stream().
+                filter(o -> o.getStatus().equals(OrderStatus.CREATING)).
+                collect(Collectors.toList());
     }
 
     @Override

--- a/src/test/java/ch/wisv/areafiftylan/OrderRestIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/OrderRestIntegrationTest.java
@@ -408,13 +408,13 @@ public class OrderRestIntegrationTest extends IntegrationTest {
             get("/users/current/orders/open").
         then().
             statusCode(HttpStatus.SC_OK).
-            body("status", equalTo("CREATING")).
-            body("reference", is(nullValue())).
-            body("user.username", is("user")).
+            body("status", hasItem(equalTo("CREATING"))).
+            body("reference", hasItem(is(nullValue()))).
+            body("user.username", hasItem(is("user"))).
             body("tickets", hasSize(1)).
-            body("tickets.type", hasItem(is("EARLY_FULL"))).
-            body("tickets.pickupService", hasItem(is(false))).
-            body("amount",equalTo(37.50F));
+            body("tickets.type", hasItem(hasItem(is("EARLY_FULL")))).
+            body("tickets.pickupService", hasItem(hasItem(is(false)))).
+            body("amount",hasItem(equalTo(37.50F)));
         //@formatter:on
     }
 
@@ -429,8 +429,8 @@ public class OrderRestIntegrationTest extends IntegrationTest {
         when().
             get("/users/current/orders/open").
         then().
-            statusCode(HttpStatus.SC_NOT_FOUND).
-            body("message", equalTo("User has no open order"));
+            statusCode(HttpStatus.SC_OK).
+            body("$", hasSize(0));
         //@formatter:on
     }
 


### PR DESCRIPTION
The Open orders of a User (which can still only be one) is now changed to a list based representation. This prevents the 404 error in the browser when there are no open orders. 

Fixes #131 