### PR TITLE
Add reference field to User response

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/model/User.java
+++ b/src/main/java/ch/wisv/areafiftylan/model/User.java
@@ -140,6 +140,11 @@ public class User implements Serializable, UserDetails {
         this.enabled = enabled;
     }
 
+    @JsonView(View.Public.class)
+    public int getReference() {
+        return username.hashCode();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {


### PR DESCRIPTION
This PR adds a reference field to the JSON response. It doesn't store anything in the database, but calculates a hash of the username field. Useful for front-end comparing logic. You can't actually do anything with it.