### PR TITLE
Correct ticket transfer mail formatting & fixed link

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/service/MailServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/service/MailServiceImpl.java
@@ -110,6 +110,6 @@ public class MailServiceImpl implements MailService {
     @Override
     public void sendTicketTransferMail(User sender, User receiver, String url) throws MessagingException {
         String message = sender.getProfile().firstName + " has send you a ticket for AreaFiftyLAN! To accept this ticket please click on the following link: " + url;
-        sendMail(receiver.getEmail(), receiver.getProfile().getFirstName() + receiver.getProfile().getLastName(), null, "A ticket for AreaFiftyLAN has been sent to you!", message);
+        sendMail(receiver.getEmail(), receiver.getProfile().getFirstName() + " " + receiver.getProfile().getLastName(), null, "A ticket for AreaFiftyLAN has been sent to you!", message);
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/service/TicketServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/service/TicketServiceImpl.java
@@ -98,7 +98,7 @@ public class TicketServiceImpl implements TicketService {
             tttRepository.save(ttt);
 
             try {
-                String acceptUrl = acceptTransferUrl + "/?token=" + ttt.getToken();
+                String acceptUrl = acceptTransferUrl + "?token=" + ttt.getToken();
                 mailService.sendTicketTransferMail(ttt.getTicket().getOwner(), ttt.getUser(), acceptUrl);
             } catch (MessagingException e) {
                 e.printStackTrace();


### PR DESCRIPTION
Fixes #194 
The link contained a redundant `/`. The name spacing is fixed, too.