### PR TITLE
TicketType deadlines

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/dto/TicketInformationResponse.java
+++ b/src/main/java/ch/wisv/areafiftylan/dto/TicketInformationResponse.java
@@ -29,6 +29,9 @@ public class TicketInformationResponse {
     @Getter
     private double pickupServicePrice;
 
+    @Getter
+    private String deadline;
+
     public TicketInformationResponse(TicketType type, int numberSold) {
         this.ticketType = type.name();
         this.limit = type.getLimit();
@@ -37,5 +40,6 @@ public class TicketInformationResponse {
         this.text = type.getText();
         this.chMemberDiscountPrice = TicketOptions.CHMEMBER.getPrice();
         this.pickupServicePrice = TicketOptions.PICKUPSERVICE.getPrice();
+        this.deadline = type.getDeadline().toString();
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/model/util/TicketType.java
+++ b/src/main/java/ch/wisv/areafiftylan/model/util/TicketType.java
@@ -1,16 +1,22 @@
 package ch.wisv.areafiftylan.model.util;
 
+import java.time.LocalDateTime;
+
 public enum TicketType {
-    EARLY_FULL("Early Bird", 37.50F, 50), REGULAR_FULL("Regular", 40.00F, 150);
+    EARLY_FULL("Early Bird", 37.50F, 50, LocalDateTime.of(2016, 6, 3, 0, 0)),
+    REGULAR_FULL("Regular", 40.00F, 0, LocalDateTime.of(2016, 5, 29, 0, 0)),
+    LAST_MINUTE("Last Minute", 45.00F, 0, LocalDateTime.of(2016, 5, 29, 0, 0));
 
     private final float price;
     private final int limit;
     private final String text;
+    private final LocalDateTime deadline;
 
-    TicketType(String text, float price, int limit) {
+    TicketType(String text, float price, int limit, LocalDateTime deadline) {
         this.text = text;
         this.price = price;
         this.limit = limit;
+        this.deadline = deadline;
     }
 
     public float getPrice() {
@@ -23,5 +29,9 @@ public enum TicketType {
 
     public String getText() {
         return text;
+    }
+
+    public LocalDateTime getDeadline() {
+        return deadline;
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/model/util/TicketType.java
+++ b/src/main/java/ch/wisv/areafiftylan/model/util/TicketType.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 public enum TicketType {
     EARLY_FULL("Early Bird", 37.50F, 50, LocalDateTime.of(2016, 6, 3, 0, 0)),
     REGULAR_FULL("Regular", 40.00F, 0, LocalDateTime.of(2016, 5, 29, 0, 0)),
-    LAST_MINUTE("Last Minute", 45.00F, 0, LocalDateTime.of(2016, 5, 29, 0, 0));
+    LAST_MINUTE("Last Minute", 45.00F, 0, LocalDateTime.of(2016, 6, 3, 0, 0));
 
     private final float price;
     private final int limit;

--- a/src/main/java/ch/wisv/areafiftylan/model/util/TicketType.java
+++ b/src/main/java/ch/wisv/areafiftylan/model/util/TicketType.java
@@ -4,8 +4,8 @@ import java.time.LocalDateTime;
 
 public enum TicketType {
     EARLY_FULL("Early Bird", 37.50F, 50, LocalDateTime.of(2016, 6, 3, 0, 0)),
-    REGULAR_FULL("Regular", 40.00F, 0, LocalDateTime.of(2016, 5, 29, 0, 0)),
-    LAST_MINUTE("Last Minute", 45.00F, 0, LocalDateTime.of(2016, 6, 3, 0, 0));
+    REGULAR_FULL("Regular", 40.00F, 0, LocalDateTime.of(2016, 5, 28, 23, 59)),
+    LAST_MINUTE("Last Minute", 45.00F, 0, LocalDateTime.of(2016, 6, 2, 23, 59));
 
     private final float price;
     private final int limit;

--- a/src/main/java/ch/wisv/areafiftylan/service/TicketServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/service/TicketServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -32,6 +33,9 @@ public class TicketServiceImpl implements TicketService {
 
     @Value("${a5l.user.acceptTransferUrl}")
     private String acceptTransferUrl;
+
+    @Value("${a5l.ticketLimit}")
+    private int TICKET_LIMIT;
 
     @Autowired
     public TicketServiceImpl(TicketRepository ticketRepository, UserService userService,
@@ -77,13 +81,23 @@ public class TicketServiceImpl implements TicketService {
     @Override
     public synchronized Ticket requestTicketOfType(TicketType type, User owner, boolean pickupService,
                                                    boolean chMember) {
-        if (ticketRepository.countByType(type) >= type.getLimit()) {
+        // Check if the TicketType has a limit and if the limit is reached
+        if (!isTicketAvailable(type)) {
             throw new TicketUnavailableException(type);
         } else {
             Ticket ticket = new Ticket(owner, type, pickupService, chMember);
             return ticketRepository.save(ticket);
         }
     }
+
+    private boolean isTicketAvailable(TicketType type) {
+        boolean typeLimitReached = type.getLimit() != 0 && ticketRepository.countByType(type) >= type.getLimit();
+        boolean eventLimitReached = ticketRepository.count() <= TICKET_LIMIT;
+        boolean deadlineExceeded = type.getDeadline().isBefore(LocalDateTime.now());
+
+        return !typeLimitReached && !deadlineExceeded && !eventLimitReached;
+    }
+
 
     @Override
     public TicketTransferToken setupForTransfer(Long ticketId, String goalUserName) {

--- a/src/main/java/ch/wisv/areafiftylan/service/TicketServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/service/TicketServiceImpl.java
@@ -92,7 +92,7 @@ public class TicketServiceImpl implements TicketService {
 
     private boolean isTicketAvailable(TicketType type) {
         boolean typeLimitReached = type.getLimit() != 0 && ticketRepository.countByType(type) >= type.getLimit();
-        boolean eventLimitReached = ticketRepository.count() <= TICKET_LIMIT;
+        boolean eventLimitReached = ticketRepository.count() >= TICKET_LIMIT;
         boolean deadlineExceeded = type.getDeadline().isBefore(LocalDateTime.now());
 
         return !typeLimitReached && !deadlineExceeded && !eventLimitReached;

--- a/src/main/resources/config/application-test.properties
+++ b/src/main/resources/config/application-test.properties
@@ -33,4 +33,6 @@ a5l.user.resetUrl=https://areafiftylan.nl/#!/resetPassword
 a5l.user.acceptTransferUrl=https://areafiftylan.nl/#!/acceptTransfer
 a5l.mail.sender=LANcie <lancie@ch.tudelft.nl>
 a5l.orderLimit=5
+a5l.ticketLimit=200
+
 

--- a/src/main/resources/config/application.properties.sample
+++ b/src/main/resources/config/application.properties.sample
@@ -62,5 +62,7 @@ a5l.user.acceptTransferUrl=https://areafiftylan.nl/#!/acceptTransfer
 # E-mail address used for sending e-mails
 a5l.mail.sender=LANcie <lancie@ch.tudelft.nl>
 a5l.orderLimit=5
+a5l.ticketLimit=200
 # API key for Google Maps
 a5l.googleMapsAPIkey=
+


### PR DESCRIPTION
This PR adds deadlines to TicketType. With this, you solve two usecases. 
1. Once the event started, you don't want to sell tickets anymore.
2. To set deadlines, you want to introduce time-sensitive Ticket Types

For the last case, the Last Minute ticket was added to the enum. Hard to test, as this depends on a hardcoded enum and LocalDateTime.now(). Open for suggestions, but as these are hardcoded values in the Enum with trivial comparisons, it _should_ be fine.

TODO:
- [x] Determine deadline
- [x] Deteremine global ticket limit