### PR TITLE
Add caching in between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: java
 jdk:
 - oraclejdk8
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 notifications:
   slack:
     rooms:


### PR DESCRIPTION
According to the travis manual [this](https://docs.travis-ci.com/user/languages/java/#Caching) is the correct way to cache gradle dependencies.