### PR TITLE
Add requesthandler to log out & delete token

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/exception/TokenNotFoundException.java
+++ b/src/main/java/ch/wisv/areafiftylan/exception/TokenNotFoundException.java
@@ -19,7 +19,7 @@ package ch.wisv.areafiftylan.exception;
 
 public class TokenNotFoundException extends RuntimeException {
 
-    public TokenNotFoundException(String token) {
-        super("could not find token '" + token + "'.");
+    public TokenNotFoundException(String message) {
+        super(message);
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/exception/TokenNotFoundException.java
+++ b/src/main/java/ch/wisv/areafiftylan/exception/TokenNotFoundException.java
@@ -19,7 +19,7 @@ package ch.wisv.areafiftylan.exception;
 
 public class TokenNotFoundException extends RuntimeException {
 
-    public TokenNotFoundException(String message) {
-        super(message);
+    public TokenNotFoundException(String token) {
+        super("Could not find token " + token);
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/exception/XAuthTokenNotFoundException.java
+++ b/src/main/java/ch/wisv/areafiftylan/exception/XAuthTokenNotFoundException.java
@@ -1,0 +1,7 @@
+package ch.wisv.areafiftylan.exception;
+
+public class XAuthTokenNotFoundException extends TokenNotFoundException {
+    public XAuthTokenNotFoundException () {
+        super("X-Auth-Token not found");
+    }
+}

--- a/src/main/java/ch/wisv/areafiftylan/exception/XAuthTokenNotFoundException.java
+++ b/src/main/java/ch/wisv/areafiftylan/exception/XAuthTokenNotFoundException.java
@@ -1,6 +1,6 @@
 package ch.wisv.areafiftylan.exception;
 
-public class XAuthTokenNotFoundException extends TokenNotFoundException {
+public class XAuthTokenNotFoundException extends RuntimeException {
     public XAuthTokenNotFoundException () {
         super("X-Auth-Token not found");
     }

--- a/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationController.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationController.java
@@ -43,7 +43,6 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
-import java.util.Optional;
 
 import static ch.wisv.areafiftylan.utils.ResponseEntityBuilder.createResponseEntity;
 
@@ -67,8 +66,7 @@ public class AuthenticationController {
     @Autowired
     public AuthenticationController(UserService userService, AuthenticationService authenticationService,
                                     VerificationTokenRepository verificationTokenRepository,
-                                    PasswordResetTokenRepository passwordResetTokenRepository,
-                                    TokenRepository<AuthenticationToken> tokenRepository) {
+                                    PasswordResetTokenRepository passwordResetTokenRepository) {
         this.userService = userService;
         this.authenticationService = authenticationService;
 
@@ -106,21 +104,11 @@ public class AuthenticationController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @RequestMapping(value = "/token/logout", method = RequestMethod.GET)
+    @RequestMapping(value = "/logout", method = RequestMethod.GET)
     public ResponseEntity<?> removeSession(@RequestHeader("X-Auth-Token") String xAuth) {
-        if (!Strings.isNullOrEmpty(xAuth)) {
-            Optional<AuthenticationToken> tokenOptional = tokenRepository.findByToken(xAuth);
-            AuthenticationToken token = tokenOptional.orElseThrow(XAuthTokenNotFoundException::new);
-            if (!token.isValid()) {
-                throw new InvalidTokenException();
-            } else {
-                token.revoke();
-                tokenRepository.saveAndFlush(token);
-                return createResponseEntity(HttpStatus.OK, "Successfully logged out");
-            }
-        } else {
-            throw new IllegalArgumentException("No X-Auth-Token present");
-        }
+        authenticationService.removeAuthToken(xAuth);
+
+        return createResponseEntity(HttpStatus.OK, "Successfully logged out");
     }
 
 

--- a/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationController.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationController.java
@@ -20,17 +20,13 @@ package ch.wisv.areafiftylan.security.authentication;
 import ch.wisv.areafiftylan.exception.InvalidTokenException;
 import ch.wisv.areafiftylan.exception.TokenNotFoundException;
 import ch.wisv.areafiftylan.exception.UserNotFoundException;
-import ch.wisv.areafiftylan.exception.XAuthTokenNotFoundException;
-import ch.wisv.areafiftylan.security.token.AuthenticationToken;
 import ch.wisv.areafiftylan.security.token.PasswordResetToken;
 import ch.wisv.areafiftylan.security.token.VerificationToken;
 import ch.wisv.areafiftylan.security.token.repository.PasswordResetTokenRepository;
-import ch.wisv.areafiftylan.security.token.repository.TokenRepository;
 import ch.wisv.areafiftylan.security.token.repository.VerificationTokenRepository;
 import ch.wisv.areafiftylan.users.model.User;
 import ch.wisv.areafiftylan.users.model.UserDTO;
 import ch.wisv.areafiftylan.users.service.UserService;
-import com.google.common.base.Strings;
 import lombok.extern.log4j.Log4j2;
 import org.apache.logging.log4j.Level;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,7 +55,6 @@ public class AuthenticationController {
     private final UserService userService;
     private final AuthenticationService authenticationService;
 
-    private final TokenRepository<AuthenticationToken> tokenRepository;
     private final VerificationTokenRepository verificationTokenRepository;
     private final PasswordResetTokenRepository passwordResetTokenRepository;
 
@@ -72,7 +67,6 @@ public class AuthenticationController {
 
         this.verificationTokenRepository = verificationTokenRepository;
         this.passwordResetTokenRepository = passwordResetTokenRepository;
-        this.tokenRepository = tokenRepository;
     }
 
     /**

--- a/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationService.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationService.java
@@ -20,4 +20,6 @@ package ch.wisv.areafiftylan.security.authentication;
 public interface AuthenticationService {
 
     String createNewAuthToken(String username, String password);
+
+    void removeAuthToken(String xAuth);
 }

--- a/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationServiceImpl.java
@@ -30,8 +30,6 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @Service
 public class AuthenticationServiceImpl implements AuthenticationService {
 
@@ -66,8 +64,8 @@ public class AuthenticationServiceImpl implements AuthenticationService {
             throw new IllegalArgumentException("No X-Auth-Token present");
         }
 
-        Optional<AuthenticationToken> tokenOptional = authenticationTokenRepository.findByToken(xAuth);
-        AuthenticationToken token = tokenOptional.orElseThrow(XAuthTokenNotFoundException::new);
+        AuthenticationToken token =
+                authenticationTokenRepository.findByToken(xAuth).orElseThrow(XAuthTokenNotFoundException::new);
 
         if (!token.isValid()) {
             throw new InvalidTokenException();


### PR DESCRIPTION
This implements a new logout endpoint to de-activate a token. It takes the current token from the header and de-activates it immediately.