### PR TITLE
Feature: Anonymous orders

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/exception/ImmutableOrderException.java
+++ b/src/main/java/ch/wisv/areafiftylan/exception/ImmutableOrderException.java
@@ -20,10 +20,6 @@ package ch.wisv.areafiftylan.exception;
 public class ImmutableOrderException extends RuntimeException {
 
     public ImmutableOrderException(Long orderId) {
-        super("No more tickets can be added to Order " + orderId);
-    }
-
-    public ImmutableOrderException(String message) {
-        super(message);
+        super("Operation on Order " + orderId + " not permitted");
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/exception/ImmutableOrderException.java
+++ b/src/main/java/ch/wisv/areafiftylan/exception/ImmutableOrderException.java
@@ -22,4 +22,8 @@ public class ImmutableOrderException extends RuntimeException {
     public ImmutableOrderException(Long orderId) {
         super("No more tickets can be added to Order " + orderId);
     }
+
+    public ImmutableOrderException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/ch/wisv/areafiftylan/exception/UnassignedOrderException.java
+++ b/src/main/java/ch/wisv/areafiftylan/exception/UnassignedOrderException.java
@@ -15,8 +15,11 @@
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package ch.wisv.areafiftylan.products.model;
+package ch.wisv.areafiftylan.exception;
 
-public enum OrderStatus {
-    ANONYMOUS, ASSIGNED, PENDING, PAID, EXPIRED, CANCELLED
+public class UnassignedOrderException extends RuntimeException {
+
+    public UnassignedOrderException(Long orderId) {
+        super("Order " + orderId + " is not assigned yet");
+    }
 }

--- a/src/main/java/ch/wisv/areafiftylan/products/controller/OrderRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/controller/OrderRestController.java
@@ -132,7 +132,9 @@ public class OrderRestController {
     @RequestMapping(value = "/orders/{orderId}", method = RequestMethod.DELETE)
     @JsonView(View.OrderOverview.class)
     public ResponseEntity<?> removeFromOrder(@PathVariable Long orderId, @RequestBody @Validated TicketDTO ticketDTO) {
-        Order modifiedOrder = orderService.removeTicketFromOrder(orderId, ticketDTO);
+        Order modifiedOrder = orderService
+                .removeTicketFromOrder(orderId, ticketDTO.getType(), ticketDTO.hasPickupService(),
+                        ticketDTO.isCHMember());
         return createResponseEntity(HttpStatus.OK, "Ticket successfully removed from Order", modifiedOrder);
     }
 

--- a/src/main/java/ch/wisv/areafiftylan/products/controller/OrderRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/controller/OrderRestController.java
@@ -79,7 +79,7 @@ public class OrderRestController {
                     "Can't order tickets with type " + ticketDTO.getType().getText());
         }
 
-        Order order = orderService.create(ticketDTO);
+        Order order = orderService.create(ticketDTO.getType(), ticketDTO.hasPickupService(), ticketDTO.isCHMember());
 
         headers.setLocation(
                 ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(order.getId()).toUri());
@@ -115,7 +115,8 @@ public class OrderRestController {
     @RequestMapping(value = "/orders/{orderId}", method = RequestMethod.POST)
     @JsonView(View.OrderOverview.class)
     public ResponseEntity<?> addToOrder(@PathVariable Long orderId, @RequestBody @Validated TicketDTO ticketDTO) {
-        Order modifiedOrder = orderService.addTicketToOrder(orderId, ticketDTO);
+        Order modifiedOrder = orderService
+                .addTicketToOrder(orderId, ticketDTO.getType(), ticketDTO.hasPickupService(), ticketDTO.isCHMember());
         return createResponseEntity(HttpStatus.OK, "Ticket successfully added to your order", modifiedOrder);
     }
 

--- a/src/main/java/ch/wisv/areafiftylan/products/controller/OrderRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/controller/OrderRestController.java
@@ -151,8 +151,8 @@ public class OrderRestController {
     @PostMapping(value = "/orders/{orderId}/assign")
     @JsonView(View.OrderOverview.class)
     public ResponseEntity<?> assignOrderToUser(Authentication auth, @PathVariable Long orderId) {
-        Order attachedOrder = orderService.assignOrderToUser(orderId, auth.getName());
-        return createResponseEntity(HttpStatus.OK, "Order successfully attached to User", attachedOrder);
+        Order assignedOrder = orderService.assignOrderToUser(orderId, auth.getName());
+        return createResponseEntity(HttpStatus.OK, "Order successfully attached to User", assignedOrder);
     }
 
 

--- a/src/main/java/ch/wisv/areafiftylan/products/controller/OrderRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/controller/OrderRestController.java
@@ -201,7 +201,7 @@ public class OrderRestController {
      */
     @RequestMapping(value = "/orders/status", method = RequestMethod.POST)
     public ResponseEntity<?> updateOrderStatus(@RequestParam(name = "id") String orderReference) {
-        orderService.updateOrderStatus(orderReference);
+        orderService.updateOrderStatusByReference(orderReference);
         return createResponseEntity(HttpStatus.OK, "Status is being updated");
     }
 
@@ -223,7 +223,7 @@ public class OrderRestController {
     @JsonView(View.OrderOverview.class)
     @RequestMapping(value = "/orders/{orderId}/status", method = RequestMethod.GET)
     public ResponseEntity<?> updateOrderStatusManual(@PathVariable long orderId) {
-        Order order = orderService.updateOrderStatus(orderId);
+        Order order = orderService.updateOrderStatusByOrderId(orderId);
         return createResponseEntity(HttpStatus.OK, "Order status updated", order);
     }
 

--- a/src/main/java/ch/wisv/areafiftylan/products/model/ExpiredOrder.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/model/ExpiredOrder.java
@@ -17,6 +17,8 @@
 
 package ch.wisv.areafiftylan.products.model;
 
+import lombok.NoArgsConstructor;
+
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import java.time.LocalDateTime;
@@ -26,6 +28,7 @@ import java.time.LocalDateTime;
  * stored in String format for reference.
  */
 @Entity
+@NoArgsConstructor
 public class ExpiredOrder {
     @Id
     private Long id;
@@ -37,10 +40,6 @@ public class ExpiredOrder {
     private String expiredAt;
 
     private String createdBy;
-
-    public ExpiredOrder() {
-        //JPA Only
-    }
 
     public ExpiredOrder(Long id, int numberOfTickets, String createdAt, String expiredAt, String createdBy) {
         this.id = id;
@@ -56,7 +55,11 @@ public class ExpiredOrder {
         this.numberOfTickets = order.getTickets().size();
         this.createdAt = order.getCreationDateTime().toString();
         this.expiredAt = LocalDateTime.now().toString();
-        this.createdBy = order.getUser().getUsername();
+        if (order.getUser() != null) {
+            this.createdBy = order.getUser().getUsername();
+        } else {
+            this.createdBy = "Anonymous";
+        }
 
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/products/model/Order.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/model/Order.java
@@ -65,13 +65,18 @@ public class Order {
     @ManyToOne(cascade = CascadeType.MERGE)
     @JsonView(View.OrderOverview.class)
     @Getter
-    @Setter
     private User user = null;
 
     public Order() {
         status = OrderStatus.ANONYMOUS;
         creationDateTime = LocalDateTime.now();
         this.tickets = new HashSet<>();
+    }
+
+    public Order(User user) {
+        this();
+        this.user = user;
+        this.status = OrderStatus.ASSIGNED;
     }
 
     public boolean addTicket(Ticket ticket) {
@@ -89,5 +94,14 @@ public class Order {
             price += ticket.getPrice();
         }
         return price;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+        if (user != null) {
+            this.status = OrderStatus.ASSIGNED;
+        } else {
+            this.status = OrderStatus.ANONYMOUS;
+        }
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/products/model/Order.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/model/Order.java
@@ -21,6 +21,8 @@ import ch.wisv.areafiftylan.users.model.User;
 import ch.wisv.areafiftylan.utils.view.View;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonView;
+import lombok.Getter;
+import lombok.Setter;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -34,53 +36,45 @@ public class Order {
     @Id
     @GeneratedValue
     @JsonView(View.OrderOverview.class)
+    @Getter
     private Long id;
 
     @OneToMany(cascade = CascadeType.MERGE, targetEntity = Ticket.class, fetch = FetchType.EAGER)
     @JsonView(View.OrderOverview.class)
+    @Getter
     private Set<Ticket> tickets;
 
     @JsonView(View.OrderOverview.class)
+    @Getter
+    @Setter
     private OrderStatus status;
 
     @JsonView(View.OrderOverview.class)
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    @Getter
     private LocalDateTime creationDateTime;
-
-    @JsonView(View.OrderOverview.class)
-    private float amount;
 
     /**
      * This String can be used to store an external reference. Payment providers often have their own id.
      */
     @JsonView(View.OrderOverview.class)
+    @Getter
+    @Setter
     private String reference;
 
     @ManyToOne(cascade = CascadeType.MERGE)
     @JsonView(View.OrderOverview.class)
-    private User user;
+    @Getter
+    @Setter
+    private User user = null;
 
-    public Order(User user) {
-        this.user = user;
-        status = OrderStatus.CREATING;
+    public Order() {
+        status = OrderStatus.ANONYMOUS;
         creationDateTime = LocalDateTime.now();
         this.tickets = new HashSet<>();
     }
 
-    public Order() {
-        //JPA only
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public Set<Ticket> getTickets() {
-        return tickets;
-    }
-
     public boolean addTicket(Ticket ticket) {
-        amount += ticket.getPrice();
         return tickets.add(ticket);
     }
 
@@ -88,30 +82,7 @@ public class Order {
         tickets.clear();
     }
 
-    public OrderStatus getStatus() {
-        return status;
-    }
-
-    public LocalDateTime getCreationDateTime() {
-        return creationDateTime;
-    }
-
-    public String getReference() {
-        return reference;
-    }
-
-    public User getUser() {
-        return user;
-    }
-
-    public void setStatus(OrderStatus status) {
-        this.status = status;
-    }
-
-    public void setReference(String reference) {
-        this.reference = reference;
-    }
-
+    @JsonView(View.OrderOverview.class)
     public float getAmount() {
         float price = 0F;
         for (Ticket ticket : this.tickets) {

--- a/src/main/java/ch/wisv/areafiftylan/products/model/OrderStatus.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/model/OrderStatus.java
@@ -18,5 +18,10 @@
 package ch.wisv.areafiftylan.products.model;
 
 public enum OrderStatus {
-    ANONYMOUS, ASSIGNED, PENDING, PAID, EXPIRED, CANCELLED
+    ANONYMOUS, // Initial creating status
+    ASSIGNED,  // Has a User assigned
+    PENDING,  // Sent to the payment provider
+    PAID,  // Confirmed paid by payment provider
+    EXPIRED, // Payment attempted, but expired
+    CANCELLED // Payment attempted, but manually cancelled
 }

--- a/src/main/java/ch/wisv/areafiftylan/products/model/Ticket.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/model/Ticket.java
@@ -20,6 +20,8 @@ package ch.wisv.areafiftylan.products.model;
 import ch.wisv.areafiftylan.users.model.User;
 import ch.wisv.areafiftylan.utils.view.View;
 import com.fasterxml.jackson.annotation.JsonView;
+import lombok.Getter;
+import lombok.Setter;
 
 import javax.persistence.*;
 
@@ -29,75 +31,59 @@ public class Ticket {
     @Id
     @GeneratedValue
     @JsonView(View.OrderOverview.class)
+    @Getter
     private Long id;
 
     @ManyToOne(cascade = CascadeType.MERGE)
     @JsonView(View.Public.class)
+    @Getter
+    @Setter
     private User owner;
 
     @Enumerated(EnumType.STRING)
     @JsonView(View.OrderOverview.class)
+    @Getter
     private TicketType type;
 
     @JsonView(View.OrderOverview.class)
+    @Getter
+    @Setter
     private String text;
 
     @JsonView(View.OrderOverview.class)
+    @Getter
+    @Setter
     private boolean pickupService;
 
     @JsonView(View.OrderOverview.class)
+    @Getter
+    @Setter
     private boolean chMember;
 
     @JsonView(View.OrderOverview.class)
+    @Getter
+    @Setter
     private boolean valid;
 
-    @JsonView(View.OrderOverview.class)
-    private float price;
-
     public Ticket(User owner, TicketType type, Boolean pickupService, Boolean chMember) {
+        this(type, pickupService, chMember);
         this.owner = owner;
+    }
+
+    public Ticket(TicketType type, Boolean pickupService, Boolean chMember) {
+        this.owner = null;
         this.type = type;
         this.text = type.getText();
         this.pickupService = pickupService;
         this.chMember = chMember;
         this.valid = false;
-
-        price = getPrice();
     }
 
     public Ticket() {
         //JPA Only
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public boolean isPickupService() {
-        return pickupService;
-    }
-
-    public void setPickupService(boolean pickupService) {
-        this.pickupService = pickupService;
-        price = getPrice();
-    }
-
-    public boolean isChMember() {
-        return chMember;
-    }
-
-    public User getOwner() {
-        return owner;
-    }
-
-    public void setOwner(User owner) {
-        this.owner = owner;
-    }
-
-    public TicketType getType() {
-        return type;
-    }
-
+    @JsonView(View.OrderOverview.class)
     public float getPrice() {
         float finalPrice = type.getPrice();
 
@@ -110,13 +96,5 @@ public class Ticket {
 
     public boolean hasPickupService() {
         return pickupService;
-    }
-
-    public boolean isValid() {
-        return valid;
-    }
-
-    public void setValid(boolean valid) {
-        this.valid = valid;
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/products/service/MolliePaymentService.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/MolliePaymentService.java
@@ -88,7 +88,7 @@ public class MolliePaymentService implements PaymentService {
     private void updateOrder(Order order, ResponseOrError<Payment> molliePayment) {
         // Insert the Mollie ID for future reference
         order.setReference(molliePayment.getData().getId());
-        order.setStatus(OrderStatus.WAITING);
+        order.setStatus(OrderStatus.PENDING);
 
         // Save the changes to the order
         orderRepository.save(order);
@@ -112,7 +112,7 @@ public class MolliePaymentService implements PaymentService {
                 // statuses to translate to our own status.
                 switch (molliePaymentStatus.getData().getStatus()) {
                     case "pending": {
-                        order.setStatus(OrderStatus.WAITING);
+                        order.setStatus(OrderStatus.PENDING);
                         break;
                     }
                     case "cancelled": {

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderService.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderService.java
@@ -20,6 +20,7 @@ package ch.wisv.areafiftylan.products.service;
 import ch.wisv.areafiftylan.products.model.Order;
 import ch.wisv.areafiftylan.products.model.TicketDTO;
 import ch.wisv.areafiftylan.products.model.TicketInformationResponse;
+import ch.wisv.areafiftylan.users.model.User;
 
 import java.util.Collection;
 import java.util.List;
@@ -37,12 +38,11 @@ public interface OrderService {
     /**
      * Create an order with at least one Ticket.
      *
-     * @param userId    User which orders the ticket
      * @param ticketDTO The ticket that is being ordered
      *
      * @return The created order
      */
-    Order create(Long userId, TicketDTO ticketDTO);
+    Order create(TicketDTO ticketDTO);
 
     /**
      * Add a ticket to an order. Checks if a ticket is available first
@@ -53,6 +53,8 @@ public interface OrderService {
      * @return The updated Order
      */
     Order addTicketToOrder(Long orderId, TicketDTO ticketDTO);
+
+    Order assignOrderToUser(Long orderId, String username);
 
     /**
      * Removes a ticket with the given DTO from an order. Throws a NotFoundException when a ticket with such a DTO can't

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderService.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderService.java
@@ -63,10 +63,12 @@ public interface OrderService {
      * Removes a ticket with the given DTO from an order. Throws a NotFoundException when a ticket with such a DTO can't
      * be found
      *
-     * @param orderId   Order from which the Ticket should be removed
-     * @param ticketDTO Ticket which should be removed from the Order
+     * @param orderId       The Id of the Order from which the tickets have to be removed
+     * @param type          The Type of the ticket to be removed
+     * @param pickupService The pickupservice bool of the ticket to be removed
+     * @param chMember      The chMember bool of the ticket to be removed
      *
-     * @return The modified Order
+     * @return The updated Order
      */
     Order removeTicketFromOrder(Long orderId, TicketType type, boolean pickupService, boolean chMember);
 
@@ -79,9 +81,9 @@ public interface OrderService {
      */
     String requestPayment(Long orderId);
 
-    Order updateOrderStatus(String orderReference);
+    Order updateOrderStatusByReference(String orderReference);
 
-    Order updateOrderStatus(Long orderId);
+    Order updateOrderStatusByOrderId(Long orderId);
 
     /**
      * Manually approve an order, without going through the paymentprovider. This method sets the Orderstatus to PAID

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderService.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderService.java
@@ -68,7 +68,7 @@ public interface OrderService {
      * @param pickupService The pickupservice bool of the ticket to be removed
      * @param chMember      The chMember bool of the ticket to be removed
      *
-     * @return The updated Order
+     * @return The updated Order where ticket has been removed if present
      */
     Order removeTicketFromOrder(Long orderId, TicketType type, boolean pickupService, boolean chMember);
 

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderService.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderService.java
@@ -18,7 +18,6 @@
 package ch.wisv.areafiftylan.products.service;
 
 import ch.wisv.areafiftylan.products.model.Order;
-import ch.wisv.areafiftylan.products.model.TicketDTO;
 import ch.wisv.areafiftylan.products.model.TicketInformationResponse;
 import ch.wisv.areafiftylan.products.model.TicketType;
 
@@ -69,7 +68,7 @@ public interface OrderService {
      *
      * @return The modified Order
      */
-    Order removeTicketFromOrder(Long orderId, TicketDTO ticketDTO);
+    Order removeTicketFromOrder(Long orderId, TicketType type, boolean pickupService, boolean chMember);
 
     /**
      * Register the order with the payment provider

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderService.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderService.java
@@ -20,7 +20,7 @@ package ch.wisv.areafiftylan.products.service;
 import ch.wisv.areafiftylan.products.model.Order;
 import ch.wisv.areafiftylan.products.model.TicketDTO;
 import ch.wisv.areafiftylan.products.model.TicketInformationResponse;
-import ch.wisv.areafiftylan.users.model.User;
+import ch.wisv.areafiftylan.products.model.TicketType;
 
 import java.util.Collection;
 import java.util.List;
@@ -36,23 +36,27 @@ public interface OrderService {
     List<Order> getOpenOrders(String username);
 
     /**
-     * Create an order with at least one Ticket.
+     * Create a new Order containing a single ticket
      *
-     * @param ticketDTO The ticket that is being ordered
+     * @param type          Ticket Type
+     * @param pickupService Ticket includes pickup service
+     * @param chMember      Ticket includes chMember
      *
-     * @return The created order
+     * @return The newly created order
      */
-    Order create(TicketDTO ticketDTO);
+    Order create(TicketType type, boolean pickupService, boolean chMember);
 
     /**
      * Add a ticket to an order. Checks if a ticket is available first
      *
-     * @param orderId   Order to which the ticket should be added
-     * @param ticketDTO DTO of the ticket to be added
+     * @param orderId
+     * @param type          Ticket Type
+     * @param pickupService Ticket includes pickup service
+     * @param chMember      Ticket includes chMember
      *
-     * @return The updated Order
+     * @return The order including the newly added ticket
      */
-    Order addTicketToOrder(Long orderId, TicketDTO ticketDTO);
+    Order addTicketToOrder(Long orderId, TicketType type, boolean pickupService, boolean chMember);
 
     Order assignOrderToUser(Long orderId, String username);
 

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
@@ -102,7 +102,7 @@ public class OrderServiceImpl implements OrderService {
         Order order = getOrderById(orderId);
 
         // Check Order status
-        if (!order.getStatus().equals(OrderStatus.ANONYMOUS) && !order.getStatus().equals(OrderStatus.ASSIGNED)) {
+        if (!(order.getStatus().equals(OrderStatus.ANONYMOUS) || order.getStatus().equals(OrderStatus.ASSIGNED))) {
             throw new ImmutableOrderException(orderId);
         }
 
@@ -143,9 +143,10 @@ public class OrderServiceImpl implements OrderService {
         if (order.getStatus().equals(OrderStatus.ANONYMOUS) || order.getStatus().equals(OrderStatus.ASSIGNED)) {
 
             // Find a Ticket in the order, equal to the given DTO. Throw an exception when the ticket doesn't exist
-            Ticket ticket =
-                    order.getTickets().stream().filter(isEqualToInput(type, pickupService, chMember)).findFirst()
-                            .orElseThrow(TicketNotFoundException::new);
+            Ticket ticket = order.getTickets().
+                    stream().
+                    filter(isEqualToInput(type, pickupService, chMember)).
+                    findFirst().orElseThrow(TicketNotFoundException::new);
 
             order.getTickets().remove(ticket);
             ticketService.removeTicket(ticket.getId());

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
@@ -146,8 +146,7 @@ public class OrderServiceImpl implements OrderService {
         if (order.getStatus().equals(OrderStatus.ANONYMOUS) || order.getStatus().equals(OrderStatus.ASSIGNED)) {
 
             // Find a Ticket in the order, equal to the given DTO. Throw an exception when the ticket doesn't exist
-            Ticket ticket = order.getTickets().
-                    stream().
+            Ticket ticket = order.getTickets().stream().
                     filter(isEqualToInput(type, pickupService, chMember)).
                     findFirst().orElseThrow(TicketNotFoundException::new);
 

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
@@ -80,12 +80,15 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
-    public Order create(TicketDTO ticketDTO) {
+    public Order create(TicketType type, boolean pickupService, boolean chMember) {
+
+        if (type == null) {
+            throw new IllegalArgumentException("TicketType can't be null!");
+        }
 
         // Request a ticket to see if one is available. If a ticket is sold out, the method ends here due to the
         // exception thrown. Else, we'll get a new ticket to add to the order.
-        Ticket ticket = ticketService
-                .requestTicketOfType(ticketDTO.getType(), ticketDTO.hasPickupService(), ticketDTO.isCHMember());
+        Ticket ticket = ticketService.requestTicketOfType(type, pickupService, chMember);
 
         Order order = new Order();
 
@@ -95,7 +98,7 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
-    public Order addTicketToOrder(Long orderId, TicketDTO ticketDTO) {
+    public Order addTicketToOrder(Long orderId, TicketType type, boolean pickupService, boolean chMember) {
         Order order = getOrderById(orderId);
 
         // Check Order status
@@ -110,8 +113,7 @@ public class OrderServiceImpl implements OrderService {
 
         // Request a ticket to see if one is available. If a ticket is sold out, the method ends here due to the
         // exception thrown. Else, we'll get a new ticket to add to the order.
-        Ticket ticket = ticketService
-                .requestTicketOfType(ticketDTO.getType(), ticketDTO.hasPickupService(), ticketDTO.isCHMember());
+        Ticket ticket = ticketService.requestTicketOfType(type, pickupService, chMember);
 
         order.addTicket(ticket);
         return orderRepository.save(order);

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
@@ -129,7 +129,7 @@ public class OrderServiceImpl implements OrderService {
         User user = userService.getUserByUsername(username);
 
         if (order.getStatus() != OrderStatus.ANONYMOUS) {
-            throw new ImmutableOrderException("Order already assigned!");
+            throw new ImmutableOrderException(order.getId());
         }
 
         order.setUser(user);

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
@@ -128,6 +128,9 @@ public class OrderServiceImpl implements OrderService {
         Order order = getOrderById(orderId);
         User user = userService.getUserByUsername(username);
 
+        // Expire all other open orders for this user
+        getOpenOrders(username).forEach(this::expireOrder);
+
         if (order.getStatus() != OrderStatus.ANONYMOUS) {
             throw new ImmutableOrderException(order.getId());
         }

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
@@ -102,7 +102,7 @@ public class OrderServiceImpl implements OrderService {
         Order order = getOrderById(orderId);
 
         // Check Order status
-        if (!order.getStatus().equals(OrderStatus.ANONYMOUS)) {
+        if (!order.getStatus().equals(OrderStatus.ANONYMOUS) && !order.getStatus().equals(OrderStatus.ASSIGNED)) {
             throw new ImmutableOrderException(orderId);
         }
 

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
@@ -113,8 +113,12 @@ public class OrderServiceImpl implements OrderService {
 
         // Request a ticket to see if one is available. If a ticket is sold out, the method ends here due to the
         // exception thrown. Else, we'll get a new ticket to add to the order.
-        Ticket ticket = ticketService.requestTicketOfType(type, pickupService, chMember);
-
+        Ticket ticket;
+        if (order.getUser() != null) {
+            ticket = ticketService.requestTicketOfType(order.getUser(), type, pickupService, chMember);
+        } else {
+            ticket = ticketService.requestTicketOfType(type, pickupService, chMember);
+        }
         order.addTicket(ticket);
         return orderRepository.save(order);
     }
@@ -123,6 +127,11 @@ public class OrderServiceImpl implements OrderService {
     public Order assignOrderToUser(Long orderId, String username) {
         Order order = getOrderById(orderId);
         User user = userService.getUserByUsername(username);
+
+        if (order.getStatus() != OrderStatus.ANONYMOUS) {
+            throw new ImmutableOrderException("Order already assigned!");
+        }
+
         order.setUser(user);
         order.setStatus(OrderStatus.ASSIGNED);
         return orderRepository.save(order);

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
@@ -140,7 +140,7 @@ public class OrderServiceImpl implements OrderService {
     @Override
     public Order removeTicketFromOrder(Long orderId, TicketType type, boolean pickupService, boolean chMember) {
         Order order = getOrderById(orderId);
-        if (order.getStatus().equals(OrderStatus.ANONYMOUS)) {
+        if (order.getStatus().equals(OrderStatus.ANONYMOUS) || order.getStatus().equals(OrderStatus.ASSIGNED)) {
 
             // Find a Ticket in the order, equal to the given DTO. Throw an exception when the ticket doesn't exist
             Ticket ticket =

--- a/src/main/java/ch/wisv/areafiftylan/products/service/TicketService.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/TicketService.java
@@ -48,14 +48,13 @@ public interface TicketService {
      * TicketUnavailableException is thrown
      *
      * @param type          Type of the Ticket requested
-     * @param owner         User that wants the Ticket
      * @param pickupService If the Ticket includes the pickupService
      *
      * @return The requested ticket, if available
      *
      * @throws TicketUnavailableException If the requested ticket is sold out.
      */
-    Ticket requestTicketOfType(TicketType type, User owner, boolean pickupService, boolean chMember);
+    Ticket requestTicketOfType(TicketType type, boolean pickupService, boolean chMember);
 
     /**
      * Sets up the ticket for transfer
@@ -92,4 +91,6 @@ public interface TicketService {
     Collection<TicketTransferToken> getValidTicketTransferTokensByUser(String username);
 
     Collection<Ticket> getAllTicketsWithTransport();
+
+    Ticket assignTicketToUser(Long TicketId, String username);
 }

--- a/src/main/java/ch/wisv/areafiftylan/products/service/TicketService.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/TicketService.java
@@ -55,6 +55,7 @@ public interface TicketService {
      * @throws TicketUnavailableException If the requested ticket is sold out.
      */
     Ticket requestTicketOfType(TicketType type, boolean pickupService, boolean chMember);
+    Ticket requestTicketOfType(User user, TicketType type, boolean pickupService, boolean chMember);
 
     /**
      * Sets up the ticket for transfer

--- a/src/main/java/ch/wisv/areafiftylan/products/service/TicketServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/TicketServiceImpl.java
@@ -107,13 +107,19 @@ public class TicketServiceImpl implements TicketService {
     }
 
     @Override
-    public synchronized Ticket requestTicketOfType(TicketType type, boolean pickupService,
+    public Ticket requestTicketOfType(TicketType type, boolean pickupService, boolean chMember) {
+        return requestTicketOfType(null, type, pickupService, chMember);
+
+    }
+
+    @Override
+    public synchronized Ticket requestTicketOfType(User user, TicketType type, boolean pickupService,
                                                    boolean chMember) {
         // Check if the TicketType has a limit and if the limit is reached
         if (!isTicketAvailable(type)) {
             throw new TicketUnavailableException(type);
         } else {
-            Ticket ticket = new Ticket(null, type, pickupService, chMember);
+            Ticket ticket = new Ticket(user, type, pickupService, chMember);
             return ticketRepository.save(ticket);
         }
     }

--- a/src/main/java/ch/wisv/areafiftylan/products/service/TicketServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/TicketServiceImpl.java
@@ -31,7 +31,6 @@ import ch.wisv.areafiftylan.users.service.UserService;
 import ch.wisv.areafiftylan.utils.mail.MailService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -108,13 +107,13 @@ public class TicketServiceImpl implements TicketService {
     }
 
     @Override
-    public synchronized Ticket requestTicketOfType(TicketType type, User owner, boolean pickupService,
+    public synchronized Ticket requestTicketOfType(TicketType type, boolean pickupService,
                                                    boolean chMember) {
         // Check if the TicketType has a limit and if the limit is reached
         if (!isTicketAvailable(type)) {
             throw new TicketUnavailableException(type);
         } else {
-            Ticket ticket = new Ticket(owner, type, pickupService, chMember);
+            Ticket ticket = new Ticket(null, type, pickupService, chMember);
             return ticketRepository.save(ticket);
         }
     }
@@ -130,8 +129,7 @@ public class TicketServiceImpl implements TicketService {
 
     @Override
     public TicketTransferToken setupForTransfer(Long ticketId, String goalUserName) {
-        User u = userService.getUserByUsername(goalUserName)
-                .orElseThrow(() -> new UsernameNotFoundException("User " + goalUserName + " not found."));
+        User u = userService.getUserByUsername(goalUserName);
         Ticket t = getTicketById(ticketId);
 
         List<TicketTransferToken> ticketTransferTokens =
@@ -197,6 +195,15 @@ public class TicketServiceImpl implements TicketService {
     public Collection<Ticket> getAllTicketsWithTransport() {
         return ticketRepository.findByPickupService_True();
     }
+
+    @Override
+    public Ticket assignTicketToUser(Long ticketId, String username) {
+        Ticket ticket = getTicketById(ticketId);
+        User user = userService.getUserByUsername(username);
+        ticket.setOwner(user);
+        return ticketRepository.save(ticket);
+    }
+
 
     private TicketTransferToken getTicketTransferTokenIfValid(String token) {
         TicketTransferToken ttt = tttRepository.findByToken(token).orElseThrow(() -> new TokenNotFoundException(token));

--- a/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationController.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationController.java
@@ -122,7 +122,7 @@ public class AuthenticationController {
 
         log.log(Level.getLevel("A5L"), "Requesting password reset on email {}.", username);
 
-        User user = userService.getUserByUsername(username).orElseThrow(() -> new UserNotFoundException(username));
+        User user = userService.getUserByUsername(username);
 
         userService.requestResetPassword(user, request);
 

--- a/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationServiceImpl.java
@@ -46,7 +46,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 
     @Override
     public String createNewAuthToken(String username, String password) {
-        User user = userService.getUserByUsername(username).orElseThrow(() -> new UsernameNotFoundException(username));
+        User user = userService.getUserByUsername(username);
 
         if (correctCredentials(user, password)) {
             // Delete the old Token

--- a/src/main/java/ch/wisv/areafiftylan/security/authentication/CurrentUserServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/authentication/CurrentUserServiceImpl.java
@@ -119,8 +119,8 @@ public class CurrentUserServiceImpl implements CurrentUserService {
     public boolean canAccessOrder(Object principal, Long orderId) {
         Order order = orderService.getOrderById(orderId);
 
+        // If the order is anonymous, allow access
         if (order.getUser() == null) {
-            // If the order is anonymous, allow access
             return true;
         }
 

--- a/src/main/java/ch/wisv/areafiftylan/security/authentication/CurrentUserServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/authentication/CurrentUserServiceImpl.java
@@ -18,6 +18,7 @@
 package ch.wisv.areafiftylan.security.authentication;
 
 import ch.wisv.areafiftylan.exception.TokenNotFoundException;
+import ch.wisv.areafiftylan.products.model.Order;
 import ch.wisv.areafiftylan.products.model.Ticket;
 import ch.wisv.areafiftylan.products.service.OrderService;
 import ch.wisv.areafiftylan.products.service.TicketRepository;
@@ -116,10 +117,17 @@ public class CurrentUserServiceImpl implements CurrentUserService {
 
     @Override
     public boolean canAccessOrder(Object principal, Long orderId) {
+        Order order = orderService.getOrderById(orderId);
+
+        if (order.getUser() == null) {
+            // If the order is anonymous, allow access
+            return true;
+        }
+
         if (principal instanceof UserDetails) {
             User user = (User) principal;
-            // Check for each of the teammembers if the username matches the requester
-            return orderService.getOrderById(orderId).getUser().getUsername().equals(user.getUsername()) ||
+            // Return true if the order is owned by the user, or the user is an admin
+            return order.getUser().getUsername().equals(user.getUsername()) ||
                     user.getAuthorities().contains(Role.ROLE_ADMIN);
         } else {
             return false;

--- a/src/main/java/ch/wisv/areafiftylan/teams/service/TeamServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/teams/service/TeamServiceImpl.java
@@ -31,7 +31,6 @@ import ch.wisv.areafiftylan.users.service.UserService;
 import ch.wisv.areafiftylan.utils.mail.MailService;
 import com.google.common.base.Strings;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
@@ -56,8 +55,7 @@ public class TeamServiceImpl implements TeamService {
 
     @Override
     public Team create(String username, String teamname) {
-        User captain =
-                userService.getUserByUsername(username).orElseThrow(() -> new UsernameNotFoundException(username));
+        User captain = userService.getUserByUsername(username);
         Team team = new Team(teamname, captain);
 
         return teamRepository.saveAndFlush(team);
@@ -106,8 +104,7 @@ public class TeamServiceImpl implements TeamService {
         // If the Captain username is set and different from the current captain, change the Captain
         String captainUsername = input.getCaptainUsername();
         if (!Strings.isNullOrEmpty(captainUsername) && !captainUsername.equals(current.getCaptain().getUsername())) {
-            User captain = userService.getUserByUsername(captainUsername)
-                    .orElseThrow(() -> new UserNotFoundException(captainUsername));
+            User captain = userService.getUserByUsername(captainUsername);
             current.setCaptain(captain);
         }
 
@@ -123,7 +120,7 @@ public class TeamServiceImpl implements TeamService {
 
     @Override
     public TeamInviteToken inviteMember(Long teamId, String username) {
-        User user = userService.getUserByUsername(username).orElseThrow(() -> new UsernameNotFoundException(username));
+        User user = userService.getUserByUsername(username);
         Team team = getTeamById(teamId);
 
         // Check if the member isn't already part of the team
@@ -194,7 +191,7 @@ public class TeamServiceImpl implements TeamService {
     @Override
     public void addMember(Long teamId, String username) {
         Team team = teamRepository.getOne(teamId);
-        User user = userService.getUserByUsername(username).orElseThrow(() -> new UserNotFoundException(username));
+        User user = userService.getUserByUsername(username);
         if (team.addMember(user)) {
             teamRepository.saveAndFlush(team);
         } else {
@@ -205,7 +202,7 @@ public class TeamServiceImpl implements TeamService {
     @Override
     public boolean removeMember(Long teamId, String username) {
         Team team = getTeamById(teamId);
-        User user = userService.getUserByUsername(username).orElseThrow(() -> new UserNotFoundException(username));
+        User user = userService.getUserByUsername(username);
         if (team.getCaptain().equals(user)) {
             return false;
         }

--- a/src/main/java/ch/wisv/areafiftylan/users/controller/UserRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/users/controller/UserRestController.java
@@ -127,7 +127,7 @@ public class UserRestController {
         if (auth != null) {
             // Get the currently logged in user from the autowired Authentication object.
             UserDetails currentUser = (UserDetails) auth.getPrincipal();
-            User user = userService.getUserByUsername(currentUser.getUsername()).get();
+            User user = userService.getUserByUsername(currentUser.getUsername());
             return new ResponseEntity<>(user, HttpStatus.OK);
         } else {
             return createResponseEntity(HttpStatus.OK, "Not logged in");

--- a/src/main/java/ch/wisv/areafiftylan/users/model/UserDTO.java
+++ b/src/main/java/ch/wisv/areafiftylan/users/model/UserDTO.java
@@ -21,8 +21,6 @@ import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.NotEmpty;
 
-import javax.validation.constraints.NotNull;
-
 public class UserDTO {
 
     @NotEmpty
@@ -35,8 +33,7 @@ public class UserDTO {
     @Setter
     private String password = "";
 
-    @NotNull
     @Getter
     @Setter
-    private Role role = Role.ROLE_USER;
+    private Long orderId;
 }

--- a/src/main/java/ch/wisv/areafiftylan/users/model/UserDTO.java
+++ b/src/main/java/ch/wisv/areafiftylan/users/model/UserDTO.java
@@ -18,22 +18,18 @@
 package ch.wisv.areafiftylan.users.model;
 
 import lombok.Getter;
-import lombok.Setter;
 import org.hibernate.validator.constraints.NotEmpty;
 
 public class UserDTO {
 
     @NotEmpty
     @Getter
-    @Setter
     private String username = "";
 
     @NotEmpty
     @Getter
-    @Setter
     private String password = "";
 
     @Getter
-    @Setter
     private Long orderId;
 }

--- a/src/main/java/ch/wisv/areafiftylan/users/service/UserService.java
+++ b/src/main/java/ch/wisv/areafiftylan/users/service/UserService.java
@@ -26,12 +26,11 @@ import org.springframework.dao.DataIntegrityViolationException;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Collection;
-import java.util.Optional;
 
 public interface UserService {
     User getUserById(long id);
 
-    Optional<User> getUserByUsername(String username);
+    User getUserByUsername(String username);
 
     Collection<User> getAllUsers();
 

--- a/src/main/java/ch/wisv/areafiftylan/users/service/UserServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/users/service/UserServiceImpl.java
@@ -151,8 +151,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     public User addProfile(Long userId, ProfileDTO profileDTO) throws DataIntegrityViolationException {
         /*
             No two identical displayNames are allowed. If the displayName already exists in the database we check
-            whether
-            this is a different user. If this is the case, we throw an exception, if not, we can continue.
+            whether this is a different user. If this is the case, we throw an exception, if not, we can continue.
          */
         userRepository.findOneByProfileDisplayNameIgnoreCase(profileDTO.getDisplayName()).ifPresent(u -> {
             if (u.getId() != userId) {

--- a/src/main/java/ch/wisv/areafiftylan/users/service/UserServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/users/service/UserServiceImpl.java
@@ -40,7 +40,6 @@ import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Collection;
-import java.util.Optional;
 
 @Service
 public class UserServiceImpl implements UserService, UserDetailsService {
@@ -70,8 +69,9 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     }
 
     @Override
-    public Optional<User> getUserByUsername(String username) {
-        return userRepository.findOneByUsernameIgnoreCase(username);
+    public User getUserByUsername(String username) {
+        return userRepository.findOneByUsernameIgnoreCase(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User '" + username + "' not found"));
     }
 
     @Override

--- a/src/main/java/ch/wisv/areafiftylan/utils/TaskScheduler.java
+++ b/src/main/java/ch/wisv/areafiftylan/utils/TaskScheduler.java
@@ -83,8 +83,8 @@ public class TaskScheduler {
     }
 
     private static Predicate<Order> isExpired() {
-        return o -> o.getStatus().equals(OrderStatus.CREATING) || o.getStatus().equals(OrderStatus.EXPIRED) ||
-                o.getStatus().equals(OrderStatus.CANCELLED);
+        return o -> o.getStatus().equals(OrderStatus.ANONYMOUS) || o.getStatus().equals(OrderStatus.ASSIGNED) ||
+                o.getStatus().equals(OrderStatus.EXPIRED) || o.getStatus().equals(OrderStatus.CANCELLED);
     }
 
     private void handleExpiredVerificationToken(VerificationToken verificationToken) {

--- a/src/main/java/ch/wisv/areafiftylan/utils/db/migration/V20161222114755__drop_amount_and_ticket.java
+++ b/src/main/java/ch/wisv/areafiftylan/utils/db/migration/V20161222114755__drop_amount_and_ticket.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016  W.I.S.V. 'Christiaan Huygens'
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ch.wisv.areafiftylan.utils.db.migration;
+
+import org.flywaydb.core.api.migration.spring.SpringJdbcMigration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class V20161222114755__drop_amount_and_ticket implements SpringJdbcMigration {
+    @Override
+    public void migrate(JdbcTemplate jdbcTemplate) throws Exception {
+        jdbcTemplate.execute("ALTER TABLE \"order\" DROP COLUMN amount; DROP TABLE \"ticket\";");
+    }
+}

--- a/src/main/resources/config/application-test.properties
+++ b/src/main/resources/config/application-test.properties
@@ -25,7 +25,7 @@ spring.jpa.show-sql=false
 spring.jpa.database-platform=org.hibernate.dialect.HSQLDialect
 spring.jpa.database=HSQL
 spring.jpa.generate-ddl=true
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.default_schema=PUBLIC
 
 #Default Property file, which is committed in Git

--- a/src/test/java/ch/wisv/areafiftylan/ApplicationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/ApplicationTest.java
@@ -61,7 +61,7 @@ public class ApplicationTest {
             @Override
             public String answer(InvocationOnMock invocation) throws Throwable {
                 Order order = (Order) invocation.getArguments()[0];
-                order.setStatus(OrderStatus.WAITING);
+                order.setStatus(OrderStatus.PENDING);
                 orderRepository.save(order);
                 return "http://paymentURL.com";
 

--- a/src/test/java/ch/wisv/areafiftylan/ApplicationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/ApplicationTest.java
@@ -25,8 +25,6 @@ import ch.wisv.areafiftylan.products.service.OrderRepository;
 import ch.wisv.areafiftylan.products.service.PaymentService;
 import ch.wisv.areafiftylan.utils.mail.MailService;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -57,15 +55,12 @@ public class ApplicationTest {
     public PaymentService paymentService(OrderRepository orderRepository) {
         MolliePaymentService mockMolliePaymentService = Mockito.mock(MolliePaymentService.class);
 
-        Mockito.when(mockMolliePaymentService.registerOrder(Mockito.any(Order.class))).then(new Answer<String>() {
-            @Override
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                Order order = (Order) invocation.getArguments()[0];
-                order.setStatus(OrderStatus.PENDING);
-                orderRepository.save(order);
-                return "http://paymentURL.com";
+        Mockito.when(mockMolliePaymentService.registerOrder(Mockito.any(Order.class))).then(invocation -> {
+            Order order = (Order) invocation.getArguments()[0];
+            order.setStatus(OrderStatus.PENDING);
+            orderRepository.save(order);
+            return "http://paymentURL.com";
 
-            }
         });
         return mockMolliePaymentService;
     }

--- a/src/test/java/ch/wisv/areafiftylan/IntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/IntegrationTest.java
@@ -24,6 +24,7 @@ import ch.wisv.areafiftylan.users.service.UserRepository;
 import ch.wisv.areafiftylan.utils.SessionData;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.filter.session.SessionFilter;
+import com.jayway.restassured.response.Header;
 import com.jayway.restassured.response.Response;
 import org.junit.After;
 import org.junit.Before;
@@ -36,9 +37,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.LocalDate;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
-import java.util.TimeZone;
 
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.config.RedirectConfig.redirectConfig;
@@ -92,30 +90,30 @@ public abstract class IntegrationTest {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }
 
-    private User makeUser(){
+    private User makeUser() {
         User user = new User("user@mail.com", new BCryptPasswordEncoder().encode(userCleartextPassword));
         user.getProfile()
-                .setAllFields("Jan", "de Groot", "MonsterKiller9001", localDate, Gender.MALE, "Mekelweg 4", "2826CD", "Delft",
-                        "0906-0666", null);
+                .setAllFields("Jan", "de Groot", "MonsterKiller9001", localDate, Gender.MALE, "Mekelweg 4", "2826CD",
+                        "Delft", "0906-0666", null);
 
         return user;
     }
 
-    private User makeAdmin(){
+    private User makeAdmin() {
         User admin = new User("admin@mail.com", new BCryptPasswordEncoder().encode(adminCleartextPassword));
         admin.addRole(Role.ROLE_ADMIN);
         admin.getProfile()
-                .setAllFields("Bert", "Kleijn", "ILoveZombies", localDate, Gender.OTHER, "Mekelweg 20", "2826CD", "Amsterdam",
-                        "0611", null);
+                .setAllFields("Bert", "Kleijn", "ILoveZombies", localDate, Gender.OTHER, "Mekelweg 20", "2826CD",
+                        "Amsterdam", "0611", null);
 
         return admin;
     }
 
-    private User makeOutsider(){
+    private User makeOutsider() {
         User outsider = new User("outsider@gmail.com", new BCryptPasswordEncoder().encode("password"));
         outsider.getProfile()
-                .setAllFields("Nottin", "Todoeo Witit", "Lookinin", localDate, Gender.FEMALE, "LoserStreet 1", "2826GJ", "China",
-                        "0906-3928", null);
+                .setAllFields("Nottin", "Todoeo Witit", "Lookinin", localDate, Gender.FEMALE, "LoserStreet 1", "2826GJ",
+                        "China", "0906-3928", null);
 
         return userRepository.saveAndFlush(outsider);
     }
@@ -125,6 +123,21 @@ public abstract class IntegrationTest {
         logout();
         userRepository.deleteAll();
         RestAssured.reset();
+    }
+
+
+    protected Header getCSRFHeader() {
+        //@formatter:off
+        Response getLoginResponse =
+            given().
+                filter(sessionFilter).
+            when().
+                get("/login").
+            then().
+                extract().response();
+        //@formatter:on
+
+        return new Header("X-CSRF-TOKEN", getLoginResponse.header("X-CSRF-TOKEN"));
     }
 
     protected SessionData login(String username, String password) {

--- a/src/test/java/ch/wisv/areafiftylan/OrderRestIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/OrderRestIntegrationTest.java
@@ -55,8 +55,10 @@ public class OrderRestIntegrationTest extends IntegrationTest {
     private final String ORDER_ENDPOINT = "/orders";
 
     private void insertTestOrders() {
-        Order order1 = new Order(user);
-        Order order2 = new Order(admin);
+        Order order1 = new Order();
+        order1.setUser(user);
+        Order order2 = new Order();
+        order2.setUser(admin);
 
         Ticket earlyAndPickup = new Ticket(user, TicketType.EARLY_FULL, true, false);
         Ticket earlyNoPickup = new Ticket(user, TicketType.EARLY_FULL, false, false);
@@ -124,7 +126,7 @@ public class OrderRestIntegrationTest extends IntegrationTest {
             statusCode(HttpStatus.SC_OK).
             body("$", hasSize(2)).
             body("user.username", containsInAnyOrder(admin.getUsername(), user.getUsername())).
-            body("status", hasItems("CREATING", "CREATING"));
+            body("status", hasItems("ANONYMOUS", "ANONYMOUS"));
         //formatter:on
     }
 
@@ -148,7 +150,7 @@ public class OrderRestIntegrationTest extends IntegrationTest {
         .then().
             statusCode(HttpStatus.SC_CREATED).
             body("object.user.username", is("user@mail.com")).
-            body("object.status", is("CREATING")).
+            body("object.status", is("ANONYMOUS")).
             body("object.tickets", hasSize(1)).
             body("object.tickets.pickupService", hasItem(true)).
             body("object.tickets.type", hasItem(is(TicketType.TEST.toString()))).
@@ -197,7 +199,7 @@ public class OrderRestIntegrationTest extends IntegrationTest {
         .then().
             statusCode(HttpStatus.SC_CREATED).
             body("object.user.username", is("user@mail.com")).
-            body("object.status", is("CREATING")).
+            body("object.status", is("ANONYMOUS")).
             body("object.tickets", hasSize(1)).
             body("object.tickets.pickupService", hasItem(false)).
             body("object.tickets.type", hasItem(is(TicketType.TEST.toString()))).
@@ -423,7 +425,7 @@ public class OrderRestIntegrationTest extends IntegrationTest {
             get(location).
         then().
             statusCode(HttpStatus.SC_OK).
-            body("status", is("CREATING")).
+            body("status", is("ANONYMOUS")).
             body("reference", is(nullValue())).
             body("user.username", is("user@mail.com")).
             body("tickets", hasSize(1)).
@@ -448,7 +450,7 @@ public class OrderRestIntegrationTest extends IntegrationTest {
             get("/users/current/orders").
         then().
             statusCode(HttpStatus.SC_OK).
-            body("[0].status", equalTo("CREATING")).
+            body("[0].status", equalTo("ANONYMOUS")).
             body("[0].reference", is(nullValue())).
             body("[0].user.username", is("user@mail.com")).
             body("[0].tickets", hasSize(1)).
@@ -473,7 +475,7 @@ public class OrderRestIntegrationTest extends IntegrationTest {
             get("/users/current/orders/open").
         then().
             statusCode(HttpStatus.SC_OK).
-            body("status", hasItem(equalTo("CREATING"))).
+            body("status", hasItem(equalTo("ANONYMOUS"))).
             body("reference", hasItem(is(nullValue()))).
             body("user.username", hasItem(is("user@mail.com"))).
             body("tickets", hasSize(1)).
@@ -534,7 +536,7 @@ public class OrderRestIntegrationTest extends IntegrationTest {
             get(location).
         then().
             statusCode(HttpStatus.SC_OK).
-            body("status", is("CREATING")).
+            body("status", is("ANONYMOUS")).
             body("reference", is(nullValue())).
             body("user.username", is("user@mail.com")).
             body("tickets.type", hasItem(is(TicketType.TEST.toString()))).
@@ -663,7 +665,8 @@ public class OrderRestIntegrationTest extends IntegrationTest {
         ticket.put("chMember", "false");
         ticket.put("type", TicketType.EARLY_FULL.toString());
 
-        Order order1 = new Order(user);
+        Order order1 = new Order();
+        order1.setUser(user);
 
         Collection<Ticket> ticketList = new ArrayList<>(5);
 
@@ -810,7 +813,7 @@ public class OrderRestIntegrationTest extends IntegrationTest {
         Long orderId = Long.parseLong(locationParse);
 
         Order order = orderRepository.findOne(orderId);
-        order.setStatus(OrderStatus.WAITING);
+        order.setStatus(OrderStatus.PENDING);
         orderRepository.save(order);
 
         SessionData login = login(user.getUsername(), userCleartextPassword);
@@ -836,7 +839,8 @@ public class OrderRestIntegrationTest extends IntegrationTest {
         ticket.put("chMember", "false");
         ticket.put("type", TicketType.EARLY_FULL.toString());
 
-        Order order1 = new Order(user);
+        Order order1 = new Order();
+        order1.setUser(user);
 
         Ticket earlyAndPickup = new Ticket(user, TicketType.EARLY_FULL, true, false);
         Ticket earlyNoPickup = new Ticket(user, TicketType.EARLY_FULL, false, false);
@@ -872,7 +876,8 @@ public class OrderRestIntegrationTest extends IntegrationTest {
         ticket.put("chMember", "false");
         ticket.put("type", TicketType.REGULAR_FULL.toString());
 
-        Order order1 = new Order(user);
+        Order order1 = new Order();
+        order1.setUser(user);
 
         Ticket earlyAndPickup = new Ticket(user, TicketType.EARLY_FULL, true, false);
         Ticket earlyNoPickup = new Ticket(user, TicketType.EARLY_FULL, false, false);
@@ -924,7 +929,7 @@ public class OrderRestIntegrationTest extends IntegrationTest {
 
         Order order = orderRepository.findOne(orderId);
 
-        assertThat("Orderstatus updated", order.getStatus(), equalTo(OrderStatus.WAITING));
+        assertThat("Orderstatus updated", order.getStatus(), equalTo(OrderStatus.PENDING));
     }
 
     @Test
@@ -952,7 +957,7 @@ public class OrderRestIntegrationTest extends IntegrationTest {
 
         Order order = orderRepository.findOne(orderId);
 
-        assertThat("Orderstatus updated", order.getStatus(), equalTo(OrderStatus.WAITING));
+        assertThat("Orderstatus updated", order.getStatus(), equalTo(OrderStatus.PENDING));
     }
 
     @Test
@@ -973,7 +978,7 @@ public class OrderRestIntegrationTest extends IntegrationTest {
 
         Order order = orderRepository.findOne(orderId);
 
-        assertThat("Orderstatus updated", order.getStatus(), equalTo(OrderStatus.CREATING));
+        assertThat("Orderstatus updated", order.getStatus(), equalTo(OrderStatus.ANONYMOUS));
     }
 
     @Test
@@ -1087,7 +1092,7 @@ public class OrderRestIntegrationTest extends IntegrationTest {
 
         Order order = orderRepository.findOne(orderId);
 
-        assertThat("Orderstatus WAITING", order.getStatus(), equalTo(OrderStatus.CREATING));
+        assertThat("Orderstatus PENDING", order.getStatus(), equalTo(OrderStatus.ANONYMOUS));
         for (Ticket ticket : order.getTickets()) {
             Assert.assertFalse(ticket.isValid());
         }

--- a/src/test/java/ch/wisv/areafiftylan/UserRestIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/UserRestIntegrationTest.java
@@ -23,7 +23,6 @@ import ch.wisv.areafiftylan.users.model.User;
 import ch.wisv.areafiftylan.utils.SessionData;
 import ch.wisv.areafiftylan.utils.TaskScheduler;
 import com.jayway.restassured.http.ContentType;
-import com.jayway.restassured.response.Header;
 import com.jayway.restassured.response.Response;
 import org.apache.http.HttpStatus;
 import org.junit.After;
@@ -58,20 +57,6 @@ public class UserRestIntegrationTest extends IntegrationTest {
     public void cleanupUserTest() {
         testUser = null;
         verificationTokenRepository.deleteAll();
-    }
-
-    private Header getCSRFHeader() {
-        //@formatter:off
-        Response getLoginResponse =
-            given().
-                filter(sessionFilter).
-            when().
-                get("/login").
-            then().
-                extract().response();
-        //@formatter:on
-
-        return new Header("X-CSRF-TOKEN", getLoginResponse.header("X-CSRF-TOKEN"));
     }
 
     private String createEnabledTestUser() {

--- a/src/test/java/ch/wisv/areafiftylan/products/service/OrderServiceTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/products/service/OrderServiceTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2016  W.I.S.V. 'Christiaan Huygens'
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ch.wisv.areafiftylan.products.service;
+
+import ch.wisv.areafiftylan.ApplicationTest;
+import ch.wisv.areafiftylan.exception.OrderNotFoundException;
+import ch.wisv.areafiftylan.products.model.Order;
+import ch.wisv.areafiftylan.products.model.OrderStatus;
+import ch.wisv.areafiftylan.users.model.Gender;
+import ch.wisv.areafiftylan.users.model.User;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.thymeleaf.spring4.SpringTemplateEngine;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ApplicationTest.class)
+@ActiveProfiles("test")
+@DataJpaTest
+public class OrderServiceTest {
+
+    @MockBean
+    SpringTemplateEngine springTemplateEngine;
+    @MockBean
+    JavaMailSender javaMailSender;
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private User persistUser() {
+        User user = new User("user@mail.com", new BCryptPasswordEncoder().encode("password"));
+        user.getProfile()
+                .setAllFields("first", "last", "display", LocalDate.now(), Gender.MALE, "address", "1234AB", "Delft",
+                        "0612345678", null);
+        return testEntityManager.persist(user);
+    }
+
+    @Before
+    public void setUp() {
+
+    }
+
+    @After
+    public void tearDown() {
+
+    }
+
+    @Test
+    public void getOrderById() {
+        Long id = testEntityManager.persistAndGetId(new Order(), Long.class);
+
+        Order order = orderService.getOrderById(id);
+
+        assertEquals(id, order.getId());
+    }
+
+    @Test
+    public void getOrderByIdNotFound() {
+        Long id = 9999L;
+        thrown.expect(OrderNotFoundException.class);
+        thrown.expectMessage("Order with id: " + id + " not found");
+
+        orderService.getOrderById(id);
+    }
+
+    @Test
+    public void getOrderByIdNull() {
+        thrown.expect(OrderNotFoundException.class);
+        thrown.expectMessage("Order with id: ");
+
+        orderService.getOrderById(null);
+    }
+
+    @Test
+    public void findOrdersByUsername() {
+        User user = persistUser();
+
+        Order order = new Order();
+        order.setUser(user);
+        order = testEntityManager.persist(order);
+
+        Collection<Order> ordersByUsername = orderService.findOrdersByUsername(user.getUsername());
+
+        assertEquals(1, ordersByUsername.size());
+    }
+
+    @Test
+    public void findOrdersByUsernameUppercase() {
+        User user = persistUser();
+
+        Order order = new Order();
+        order.setUser(user);
+        order = testEntityManager.persist(order);
+
+        Collection<Order> ordersByUsername = orderService.findOrdersByUsername(user.getUsername().toUpperCase());
+
+        assertEquals(1, ordersByUsername.size());
+
+    }
+
+    @Test
+    public void findOrdersByUsernameMultipleOrders() {
+        User user = persistUser();
+
+        Order order = new Order();
+        Order order2 = new Order();
+        order.setUser(user);
+        order2.setUser(user);
+        testEntityManager.persist(order);
+        testEntityManager.persist(order2);
+
+        Collection<Order> ordersByUsername = orderService.findOrdersByUsername(user.getUsername());
+
+        assertEquals(2, ordersByUsername.size());
+    }
+
+    @Test
+    public void findOrdersByUsernameNull() {
+        User user = persistUser();
+
+        Order order = new Order();
+        order.setUser(user);
+        testEntityManager.persist(order);
+
+        Collection<Order> ordersByUsername = orderService.findOrdersByUsername(null);
+
+        assertEquals(0, ordersByUsername.size());
+    }
+
+    @Test
+    public void getOpenOrders() {
+        User user = persistUser();
+
+        Order order = new Order();
+        order.setUser(user);
+        testEntityManager.persist(order);
+        Order order2 = new Order();
+        order.setUser(user);
+        order.setStatus(OrderStatus.PAID);
+        testEntityManager.persist(order2);
+
+        List<Order> openOrders = orderService.getOpenOrders(user.getUsername());
+
+        assertEquals(1, openOrders.size());
+    }
+
+    @Test
+    public void create() {
+
+    }
+
+    @Test
+    public void addTicketToOrder() {
+
+    }
+
+    @Test
+    public void assignOrderToUser() {
+
+    }
+
+    @Test
+    public void removeTicketFromOrder() {
+
+    }
+
+    @Test
+    public void requestPayment() {
+
+    }
+
+    @Test
+    public void updateOrderStatus() {
+
+    }
+
+    @Test
+    public void updateOrderStatus1() {
+
+    }
+
+    @Test
+    public void adminApproveOrder() {
+
+    }
+
+    @Test
+    public void expireOrder() {
+
+    }
+
+    @Test
+    public void getAvailableTickets() {
+
+    }
+
+}

--- a/src/test/java/ch/wisv/areafiftylan/products/service/OrderServiceTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/products/service/OrderServiceTest.java
@@ -356,6 +356,24 @@ public class OrderServiceTest {
     }
 
     @Test
+    public void assignOrderToUserWithOpenOrder() {
+        User user = persistUser();
+        Order order = new Order();
+        Order order2 = new Order();
+        order.addTicket(testEntityManager.persist(new Ticket(TicketType.TEST, true, true)));
+        order2.addTicket(testEntityManager.persist(new Ticket(TicketType.TEST, true, true)));
+
+        Long id = testEntityManager.persistAndGetId(order, Long.class);
+        Long id2 = testEntityManager.persistAndGetId(order2, Long.class);
+
+        orderService.assignOrderToUser(id, user.getUsername());
+        orderService.assignOrderToUser(id2, user.getUsername());
+
+        assertEquals(user, testEntityManager.find(Order.class, id2).getUser());
+        assertNull(testEntityManager.find(Order.class, id));
+    }
+
+    @Test
     public void assignOrderToUserOrderNotFound() {
         thrown.expect(OrderNotFoundException.class);
 

--- a/src/test/java/ch/wisv/areafiftylan/products/service/OrderServiceTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/products/service/OrderServiceTest.java
@@ -444,7 +444,6 @@ public class OrderServiceTest {
     @Test
     public void assignOrderToUserAlreadyAssigned() {
         thrown.expect(ImmutableOrderException.class);
-        thrown.expectMessage("Order already assigned!");
 
         User user = persistUser();
         User user2 =


### PR DESCRIPTION
This PR introduces the new Order flow for A5L 2017. 

Orders are created anonymous by default, at which point tickets can be added by anyone. Before checkout, the Order should be assigned to a User, after which the old functionality applies. 

A new methodology is introduced for the testing of Services. It follows a more Unit-like testing method, resulting in a huge speed increase and better coverage. 

The OrderRestIntegrationTest is sub-optimal, but as #262 is going to be implemented soon, I didn't bother with a detailed overhaul. 

Fixes #271 
Fixes #272 
Fixes #282 
Fixes #302 