### PR TITLE
Change removeTicket from order to id

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/products/controller/OrderRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/controller/OrderRestController.java
@@ -122,10 +122,11 @@ public class OrderRestController {
      * @return Message about the result of the request
      */
     @PreAuthorize("@currentUserServiceImpl.canAccessOrder(principal, #orderId)")
-    @RequestMapping(value = "/orders/{orderId}", method = RequestMethod.DELETE)
+    @RequestMapping(value = "/orders/{orderId}/{ticketId}", method = RequestMethod.DELETE)
     @JsonView(View.OrderOverview.class)
-    public ResponseEntity<?> removeFromOrder(@PathVariable Long orderId, @RequestBody @Validated TicketDTO ticketDTO) {
-        Order modifiedOrder = orderService.removeTicketFromOrder(orderId, ticketDTO.getType(), ticketDTO.getOptions());
+    public ResponseEntity<?> removeFromOrder(@PathVariable Long orderId, @PathVariable Long ticketId) {
+        Order modifiedOrder = orderService
+                .removeTicketFromOrder(orderId, ticketId);
         return createResponseEntity(HttpStatus.OK, "Ticket successfully removed from Order", modifiedOrder);
     }
 

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderService.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderService.java
@@ -48,8 +48,13 @@ public interface OrderService {
     /**
      * Removes a ticket with the given DTO from an order. Throws a NotFoundException when a ticket with such a DTO can't
      * be found
+     *
+     * @param orderId       The Id of the Order from which the tickets have to be removed
+     * @param ticketId      The Id of the Ticket to remove from the order
+     *
+     * @return The updated Order where ticket has been removed if present
      */
-    Order removeTicketFromOrder(Long orderId, String type, List<String> options);
+    Order removeTicketFromOrder(Long orderId, Long ticketId);
 
     /**
      * Register the order with the payment provider

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
@@ -20,7 +20,6 @@ package ch.wisv.areafiftylan.products.service;
 import ch.wisv.areafiftylan.exception.*;
 import ch.wisv.areafiftylan.products.model.Ticket;
 import ch.wisv.areafiftylan.products.model.TicketInformationResponse;
-import ch.wisv.areafiftylan.products.model.TicketOption;
 import ch.wisv.areafiftylan.products.model.TicketType;
 import ch.wisv.areafiftylan.products.model.order.ExpiredOrder;
 import ch.wisv.areafiftylan.products.model.order.Order;
@@ -37,7 +36,6 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @Service
@@ -155,14 +153,13 @@ public class OrderServiceImpl implements OrderService {
 
             // Find a Ticket in the order, equal to the given DTO. Throw an exception when the ticket doesn't exist
             Ticket ticket = order.getTickets().stream().
-                    filter(t -> t.getId() == ticketId).
+                    filter(t -> t.getId().equals(ticketId)).
                     findFirst().orElseThrow(TicketNotFoundException::new);
 
             order.getTickets().remove(ticket);
             ticketService.removeTicket(ticket.getId());
 
             return orderRepository.save(order);
-
         } else {
             throw new ImmutableOrderException(orderId);
         }

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
@@ -149,13 +149,13 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
-    public Order removeTicketFromOrder(Long orderId, String type, List<String> options) {
+    public Order removeTicketFromOrder(Long orderId, Long ticketId) {
         Order order = getOrderById(orderId);
         if (order.getStatus().equals(OrderStatus.ANONYMOUS) || order.getStatus().equals(OrderStatus.ASSIGNED)) {
 
             // Find a Ticket in the order, equal to the given DTO. Throw an exception when the ticket doesn't exist
             Ticket ticket = order.getTickets().stream().
-                    filter(isEqualToInput(type, options)).
+                    filter(t -> t.getId() == ticketId).
                     findFirst().orElseThrow(TicketNotFoundException::new);
 
             order.getTickets().remove(ticket);
@@ -166,14 +166,6 @@ public class OrderServiceImpl implements OrderService {
         } else {
             throw new ImmutableOrderException(orderId);
         }
-    }
-
-    private static Predicate<Ticket> isEqualToInput(String type, List<String> options) {
-
-        return t -> (t.getType().getName().equals(type) && t.getEnabledOptions().stream().
-                map(TicketOption::getName).
-                collect(Collectors.toList()).
-                containsAll(options));
     }
 
     @Override

--- a/src/main/java/ch/wisv/areafiftylan/products/service/TicketService.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/TicketService.java
@@ -30,7 +30,7 @@ import java.util.List;
 public interface TicketService {
     Ticket getTicketById(Long ticketId);
 
-    Ticket removeTicket(Long ticketId);
+    void removeTicket(Long ticketId);
 
     Integer getNumberSoldOfType(TicketType type);
 

--- a/src/main/java/ch/wisv/areafiftylan/products/service/TicketService.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/TicketService.java
@@ -30,7 +30,7 @@ import java.util.List;
 public interface TicketService {
     Ticket getTicketById(Long ticketId);
 
-    void removeTicket(Long ticketId);
+    Ticket removeTicket(Long ticketId);
 
     Integer getNumberSoldOfType(TicketType type);
 
@@ -50,8 +50,6 @@ public interface TicketService {
      * TicketUnavailableException is thrown
      *
      * @param type          Type of the Ticket requested
-     * @param pickupService If the Ticket includes the pickupService
-     *
      * @return The requested ticket, if available
      *
      * @throws TicketUnavailableException If the requested ticket is sold out.

--- a/src/main/java/ch/wisv/areafiftylan/products/service/TicketServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/TicketServiceImpl.java
@@ -87,10 +87,8 @@ public class TicketServiceImpl implements TicketService {
     }
 
     @Override
-    public Ticket removeTicket(Long ticketId) {
-        Ticket ticket = getTicketById(ticketId);
-        ticketRepository.delete(ticket);
-        return ticket;
+    public void removeTicket(Long ticketId) {
+        ticketRepository.delete(ticketId);
     }
 
     @Override

--- a/src/main/java/ch/wisv/areafiftylan/products/service/TicketServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/TicketServiceImpl.java
@@ -87,8 +87,10 @@ public class TicketServiceImpl implements TicketService {
     }
 
     @Override
-    public void removeTicket(Long ticketId) {
-        ticketRepository.delete(ticketId);
+    public Ticket removeTicket(Long ticketId) {
+        Ticket ticket = getTicketById(ticketId);
+        ticketRepository.delete(ticket);
+        return ticket;
     }
 
     @Override

--- a/src/test/java/ch/wisv/areafiftylan/products/service/OrderServiceTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/products/service/OrderServiceTest.java
@@ -177,7 +177,7 @@ public class OrderServiceTest extends ServiceTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void createNullType() {
-        Order order = orderService.create(null, Arrays.asList(CH_MEMBER_OPTION, PICKUP_SERVICE_OPTION));
+        orderService.create(null, Arrays.asList(CH_MEMBER_OPTION, PICKUP_SERVICE_OPTION));
         assertEquals(0, orderRepository.findAll().size());
     }
 
@@ -406,8 +406,8 @@ public class OrderServiceTest extends ServiceTest {
     @Test
     public void removeTicketFromOrder() {
         Order order = new Order();
-        Ticket ticket = new Ticket(TicketType.TEST, true, true);
-        order.addTicket(testEntityManager.persist(ticket));
+        Ticket ticket = persistTicket();
+        order.addTicket(ticket);
 
         Long id = testEntityManager.persistAndGetId(order, Long.class);
 
@@ -428,8 +428,8 @@ public class OrderServiceTest extends ServiceTest {
     @Test
     public void removeTicketFromOrderTicketNotFound() {
         Order order = new Order();
-        Ticket ticket = new Ticket(TicketType.TEST, true, true);
-        order.addTicket(testEntityManager.persist(ticket));
+        Ticket ticket = persistTicket();
+        order.addTicket(ticket);
 
         Long id = testEntityManager.persistAndGetId(order, Long.class);
 
@@ -445,8 +445,8 @@ public class OrderServiceTest extends ServiceTest {
     @Test
     public void removeTicketFromOrderTypeNull() {
         Order order = new Order();
-        Ticket ticket = new Ticket(TicketType.TEST, true, true);
-        order.addTicket(testEntityManager.persist(ticket));
+        Ticket ticket = persistTicket();
+        order.addTicket(ticket);
 
         Long id = testEntityManager.persistAndGetId(order, Long.class);
 
@@ -460,25 +460,10 @@ public class OrderServiceTest extends ServiceTest {
     }
 
     @Test
-    public void removeTicketFromOrderTwoMatchingTickets() {
+    public void removeTicketFromOrderDeleteTwo() {
         Order order = new Order();
-        Ticket ticket1 = new Ticket(TicketType.TEST, true, true);
-        Ticket ticket2 = new Ticket(TicketType.TEST, true, true);
-        order.addTicket(testEntityManager.persist(ticket1));
-        order.addTicket(testEntityManager.persist(ticket2));
-
-        Long id = testEntityManager.persistAndGetId(order, Long.class);
-
-        assertEquals(2, testEntityManager.find(Order.class, id).getTickets().size());
-        orderService.removeTicketFromOrder(id, ticket1.getId());
-        assertEquals(1, testEntityManager.find(Order.class, id).getTickets().size());
-    }
-
-    @Test
-    public void removeTicketFromOrderTwoMatchingTicketsDeleteTwice() {
-        Order order = new Order();
-        Ticket ticket1 = new Ticket(TicketType.TEST, true, true);
-        Ticket ticket2 = new Ticket(TicketType.TEST, true, true);
+        Ticket ticket1 = persistTicket();
+        Ticket ticket2 = persistTicket();
         order.addTicket(testEntityManager.persist(ticket1));
         order.addTicket(testEntityManager.persist(ticket2));
 
@@ -497,9 +482,9 @@ public class OrderServiceTest extends ServiceTest {
         thrown.expect(OrderNotFoundException.class);
 
         Order order = new Order();
-        Ticket ticket = new Ticket(TicketType.TEST, true, true);
+        Ticket ticket = persistTicket();
         order.addTicket(testEntityManager.persist(ticket));
-        Long id = testEntityManager.persistAndGetId(order, Long.class);
+        testEntityManager.persistAndGetId(order, Long.class);
 
         orderService.removeTicketFromOrder(9999L, ticket.getId());
     }
@@ -509,9 +494,9 @@ public class OrderServiceTest extends ServiceTest {
         thrown.expect(OrderNotFoundException.class);
 
         Order order = new Order();
-        Ticket ticket = new Ticket(TicketType.TEST, true, true);
+        Ticket ticket = persistTicket();
         order.addTicket(testEntityManager.persist(ticket));
-        Long id = testEntityManager.persistAndGetId(order, Long.class);
+        testEntityManager.persistAndGetId(order, Long.class);
 
         orderService.removeTicketFromOrder(null, ticket.getId());
     }
@@ -523,7 +508,7 @@ public class OrderServiceTest extends ServiceTest {
         order.addTicket(persistTicket());
 
         Long id = testEntityManager.persistAndGetId(order, Long.class);
-        String payment = orderService.requestPayment(id);
+        orderService.requestPayment(id);
         verify(paymentService, times(1)).registerOrder(Mockito.any(Order.class));
         reset(paymentService);
     }
@@ -535,7 +520,7 @@ public class OrderServiceTest extends ServiceTest {
 
         Long id = testEntityManager.persistAndGetId(order, Long.class);
         try {
-            String payment = orderService.requestPayment(id);
+            orderService.requestPayment(id);
         } catch (IllegalStateException e) {
             assertEquals("Order can not be empty", e.getMessage());
             verify(paymentService, never()).registerOrder(Mockito.any(Order.class));
@@ -552,7 +537,7 @@ public class OrderServiceTest extends ServiceTest {
 
         Long id = testEntityManager.persistAndGetId(order, Long.class);
         try {
-            String payment = orderService.requestPayment(id);
+            orderService.requestPayment(id);
         } catch (UnassignedOrderException e) {
             verify(paymentService, never()).registerOrder(Mockito.any(Order.class));
         } finally {
@@ -566,9 +551,9 @@ public class OrderServiceTest extends ServiceTest {
         Order order = new Order(user);
         order.addTicket(persistTicket());
 
-        Long id = testEntityManager.persistAndGetId(order, Long.class);
+        testEntityManager.persistAndGetId(order, Long.class);
         try {
-            String payment = orderService.requestPayment(null);
+            orderService.requestPayment(null);
         } catch (OrderNotFoundException e) {
             verify(paymentService, never()).registerOrder(Mockito.any(Order.class));
         } finally {

--- a/src/test/java/ch/wisv/areafiftylan/products/service/OrderServiceTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/products/service/OrderServiceTest.java
@@ -406,11 +406,12 @@ public class OrderServiceTest extends ServiceTest {
     @Test
     public void removeTicketFromOrder() {
         Order order = new Order();
-        order.addTicket(persistTicket());
+        Ticket ticket = new Ticket(TicketType.TEST, true, true);
+        order.addTicket(testEntityManager.persist(ticket));
 
         Long id = testEntityManager.persistAndGetId(order, Long.class);
 
-        orderService.removeTicketFromOrder(id, TEST_TICKET, Arrays.asList(CH_MEMBER_OPTION, PICKUP_SERVICE_OPTION));
+        orderService.removeTicketFromOrder(id, ticket.getId());
 
         assertEquals(0, testEntityManager.find(Order.class, id).getTickets().size());
     }
@@ -421,20 +422,21 @@ public class OrderServiceTest extends ServiceTest {
         Order order = new Order();
         Long id = testEntityManager.persistAndGetId(order, Long.class);
 
-        orderService.removeTicketFromOrder(id, TEST_TICKET, Arrays.asList(CH_MEMBER_OPTION, PICKUP_SERVICE_OPTION));
+        orderService.removeTicketFromOrder(id, 4L);
     }
 
     @Test
     public void removeTicketFromOrderTicketNotFound() {
         Order order = new Order();
-        order.addTicket(persistTicket());
+        Ticket ticket = new Ticket(TicketType.TEST, true, true);
+        order.addTicket(testEntityManager.persist(ticket));
 
         Long id = testEntityManager.persistAndGetId(order, Long.class);
 
         assertEquals(1, testEntityManager.find(Order.class, id).getTickets().size());
 
         try {
-            orderService.removeTicketFromOrder(id, TEST_TICKET, Arrays.asList(CH_MEMBER_OPTION, PICKUP_SERVICE_OPTION));
+            orderService.removeTicketFromOrder(id, ticket.getId());
         } catch (TicketNotFoundException e) {
             assertEquals(1, testEntityManager.find(Order.class, id).getTickets().size());
         }
@@ -443,14 +445,15 @@ public class OrderServiceTest extends ServiceTest {
     @Test
     public void removeTicketFromOrderTypeNull() {
         Order order = new Order();
-        order.addTicket(persistTicket());
+        Ticket ticket = new Ticket(TicketType.TEST, true, true);
+        order.addTicket(testEntityManager.persist(ticket));
 
         Long id = testEntityManager.persistAndGetId(order, Long.class);
 
         assertEquals(1, testEntityManager.find(Order.class, id).getTickets().size());
 
         try {
-            orderService.removeTicketFromOrder(id, null, Arrays.asList(CH_MEMBER_OPTION, PICKUP_SERVICE_OPTION));
+            orderService.removeTicketFromOrder(id, ticket.getId() + 1);
         } catch (TicketNotFoundException e) {
             assertEquals(1, testEntityManager.find(Order.class, id).getTickets().size());
         }
@@ -459,28 +462,32 @@ public class OrderServiceTest extends ServiceTest {
     @Test
     public void removeTicketFromOrderTwoMatchingTickets() {
         Order order = new Order();
-        order.addTicket(persistTicket());
-        order.addTicket(persistTicket());
+        Ticket ticket1 = new Ticket(TicketType.TEST, true, true);
+        Ticket ticket2 = new Ticket(TicketType.TEST, true, true);
+        order.addTicket(testEntityManager.persist(ticket1));
+        order.addTicket(testEntityManager.persist(ticket2));
 
         Long id = testEntityManager.persistAndGetId(order, Long.class);
 
         assertEquals(2, testEntityManager.find(Order.class, id).getTickets().size());
-        orderService.removeTicketFromOrder(id, TEST_TICKET, Arrays.asList(CH_MEMBER_OPTION, PICKUP_SERVICE_OPTION));
+        orderService.removeTicketFromOrder(id, ticket1.getId());
         assertEquals(1, testEntityManager.find(Order.class, id).getTickets().size());
     }
 
     @Test
     public void removeTicketFromOrderTwoMatchingTicketsDeleteTwice() {
         Order order = new Order();
-        order.addTicket(persistTicket());
-        order.addTicket(persistTicket());
+        Ticket ticket1 = new Ticket(TicketType.TEST, true, true);
+        Ticket ticket2 = new Ticket(TicketType.TEST, true, true);
+        order.addTicket(testEntityManager.persist(ticket1));
+        order.addTicket(testEntityManager.persist(ticket2));
 
         Long id = testEntityManager.persistAndGetId(order, Long.class);
 
         assertEquals(2, testEntityManager.find(Order.class, id).getTickets().size());
-        orderService.removeTicketFromOrder(id, TEST_TICKET, Arrays.asList(CH_MEMBER_OPTION, PICKUP_SERVICE_OPTION));
+        orderService.removeTicketFromOrder(id, ticket1.getId());
         assertEquals(1, testEntityManager.find(Order.class, id).getTickets().size());
-        orderService.removeTicketFromOrder(id, TEST_TICKET, Arrays.asList(CH_MEMBER_OPTION, PICKUP_SERVICE_OPTION));
+        orderService.removeTicketFromOrder(id, ticket2.getId());
         assertEquals(0, testEntityManager.find(Order.class, id).getTickets().size());
     }
 
@@ -490,10 +497,11 @@ public class OrderServiceTest extends ServiceTest {
         thrown.expect(OrderNotFoundException.class);
 
         Order order = new Order();
-        order.addTicket(persistTicket());
+        Ticket ticket = new Ticket(TicketType.TEST, true, true);
+        order.addTicket(testEntityManager.persist(ticket));
         Long id = testEntityManager.persistAndGetId(order, Long.class);
 
-        orderService.removeTicketFromOrder(9999L, TEST_TICKET, Arrays.asList(CH_MEMBER_OPTION, PICKUP_SERVICE_OPTION));
+        orderService.removeTicketFromOrder(9999L, ticket.getId());
     }
 
     @Test
@@ -501,10 +509,11 @@ public class OrderServiceTest extends ServiceTest {
         thrown.expect(OrderNotFoundException.class);
 
         Order order = new Order();
-        order.addTicket(persistTicket());
+        Ticket ticket = new Ticket(TicketType.TEST, true, true);
+        order.addTicket(testEntityManager.persist(ticket));
         Long id = testEntityManager.persistAndGetId(order, Long.class);
 
-        orderService.removeTicketFromOrder(null, TEST_TICKET, Arrays.asList(CH_MEMBER_OPTION, PICKUP_SERVICE_OPTION));
+        orderService.removeTicketFromOrder(null, ticket.getId());
     }
 
     @Test


### PR DESCRIPTION
Ticket removal is quite weird to remove a random ticket whichever is found first. It is more logical to be able to remove on ticketId in an Order.

Also, tests are failing but I can't figure out what is happening right now. I suppose this is due to the fact that the OrderRestIntegrationTest has not been updated yet? It gives me a failing test, but it does succeed when the test is run with no other tests.