### PR TITLE
Unify updating of OrderStatus

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
@@ -205,7 +205,7 @@ public class OrderServiceImpl implements OrderService {
     public Order updateOrderStatusByOrderId(Long orderId) {
         Order order = getOrderById(orderId);
         if (!Strings.isNullOrEmpty(order.getReference())) {
-            return paymentService.updateStatus(order.getReference());
+            return updateOrderStatusByReference(order.getReference());
         } else {
             throw new PaymentException("Order with id " + order + " has not been checked out yet");
         }


### PR DESCRIPTION
We had two methods, one via OrderID, another one via OrderReference. They should do the same, they didn't. 