### PR TITLE
Implement JsonUsernamePasswordAuthentication via Filter

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/security/JsonLoginAuthenticationSuccessHandler.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/JsonLoginAuthenticationSuccessHandler.java
@@ -18,8 +18,6 @@
 package ch.wisv.areafiftylan.security;
 
 import ch.wisv.areafiftylan.security.authentication.AuthenticationService;
-import lombok.Setter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 
@@ -30,11 +28,7 @@ import java.io.IOException;
 
 public class JsonLoginAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
 
-    @Autowired
-    AuthenticationService authenticationService;
-
-    @Setter
-    String username = "";
+    private final AuthenticationService authenticationService;
 
     public JsonLoginAuthenticationSuccessHandler(AuthenticationService service) {
         this.authenticationService = service;
@@ -43,7 +37,7 @@ public class JsonLoginAuthenticationSuccessHandler implements AuthenticationSucc
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException, ServletException {
-        response.setHeader("X-Auth-Token", authenticationService.createNewAuthToken(username));
+        response.setHeader("X-Auth-Token", authenticationService.createNewAuthToken(authentication.getName()));
         response.setStatus(200);
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/security/JsonLoginAuthenticationSuccessHandler.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/JsonLoginAuthenticationSuccessHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017  W.I.S.V. 'Christiaan Huygens'
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ch.wisv.areafiftylan.security;
+
+import ch.wisv.areafiftylan.security.authentication.AuthenticationService;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class JsonLoginAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    @Autowired
+    AuthenticationService authenticationService;
+
+    @Setter
+    String username = "";
+
+    public JsonLoginAuthenticationSuccessHandler(AuthenticationService service) {
+        this.authenticationService = service;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        response.setHeader("X-Auth-Token", authenticationService.createNewAuthToken(username));
+        response.setStatus(200);
+    }
+}

--- a/src/main/java/ch/wisv/areafiftylan/security/JsonLoginFilter.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/JsonLoginFilter.java
@@ -32,27 +32,21 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.Reader;
 
+/**
+ * This Login filter uses the default "Form" login filter, but parses a JSON requestbody instead. It accepts requests on
+ * /login and returns an X-Auth-Token Header on successful authentication using the
+ * JsonLoginAuthenticationSuccessHandler
+ */
 public class JsonLoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private UserDTO userDTO = new UserDTO();
     private AuthenticationManager authenticationManager;
     private JsonLoginAuthenticationSuccessHandler successHandler;
 
-    public JsonLoginFilter(AuthenticationManager authenticationManager,
-                           JsonLoginAuthenticationSuccessHandler successHandler) {
+    public JsonLoginFilter(AuthenticationManager authenticationManager, JsonLoginAuthenticationSuccessHandler successHandler) {
         super();
         this.authenticationManager = authenticationManager;
         this.successHandler = successHandler;
-    }
-
-    @Override
-    protected String obtainUsername(HttpServletRequest request) {
-        return userDTO.getUsername();
-    }
-
-    @Override
-    protected String obtainPassword(HttpServletRequest request) {
-        return userDTO.getPassword();
     }
 
     @Override
@@ -60,6 +54,12 @@ public class JsonLoginFilter extends UsernamePasswordAuthenticationFilter {
             throws AuthenticationException {
         userDTO = getUserDTO(request);
         return super.attemptAuthentication(request, response);
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+                                            Authentication authResult) throws IOException, ServletException {
+        successHandler.onAuthenticationSuccess(request, response, authResult);
     }
 
     private UserDTO getUserDTO(HttpServletRequest request) {
@@ -73,6 +73,16 @@ public class JsonLoginFilter extends UsernamePasswordAuthenticationFilter {
     }
 
     @Override
+    protected String obtainUsername(HttpServletRequest request) {
+        return userDTO.getUsername();
+    }
+
+    @Override
+    protected String obtainPassword(HttpServletRequest request) {
+        return userDTO.getPassword();
+    }
+
+    @Override
     public AuthenticationManager getAuthenticationManager() {
         return this.authenticationManager;
     }
@@ -80,12 +90,5 @@ public class JsonLoginFilter extends UsernamePasswordAuthenticationFilter {
     @Override
     public void setAuthenticationSuccessHandler(AuthenticationSuccessHandler successHandler) {
         super.setAuthenticationSuccessHandler(successHandler);
-    }
-
-    @Override
-    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
-                                            Authentication authResult) throws IOException, ServletException {
-        successHandler.setUsername(userDTO.getUsername());
-        successHandler.onAuthenticationSuccess(request, response, authResult);
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/security/JsonLoginFilter.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/JsonLoginFilter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2017  W.I.S.V. 'Christiaan Huygens'
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ch.wisv.areafiftylan.security;
+
+import ch.wisv.areafiftylan.users.model.UserDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Reader;
+
+public class JsonLoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private UserDTO userDTO = new UserDTO();
+    private AuthenticationManager authenticationManager;
+    private JsonLoginAuthenticationSuccessHandler successHandler;
+
+    public JsonLoginFilter(AuthenticationManager authenticationManager,
+                           JsonLoginAuthenticationSuccessHandler successHandler) {
+        super();
+        this.authenticationManager = authenticationManager;
+        this.successHandler = successHandler;
+    }
+
+    @Override
+    protected String obtainUsername(HttpServletRequest request) {
+        return userDTO.getUsername();
+    }
+
+    @Override
+    protected String obtainPassword(HttpServletRequest request) {
+        return userDTO.getPassword();
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException {
+        userDTO = getUserDTO(request);
+        return super.attemptAuthentication(request, response);
+    }
+
+    private UserDTO getUserDTO(HttpServletRequest request) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            Reader reader = request.getReader();
+            return mapper.readValue(reader, UserDTO.class);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Cant read request data");
+        }
+    }
+
+    @Override
+    public AuthenticationManager getAuthenticationManager() {
+        return this.authenticationManager;
+    }
+
+    @Override
+    public void setAuthenticationSuccessHandler(AuthenticationSuccessHandler successHandler) {
+        super.setAuthenticationSuccessHandler(successHandler);
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+                                            Authentication authResult) throws IOException, ServletException {
+        successHandler.setUsername(userDTO.getUsername());
+        successHandler.onAuthenticationSuccess(request, response, authResult);
+    }
+}

--- a/src/main/java/ch/wisv/areafiftylan/security/SecurityConfiguration.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/SecurityConfiguration.java
@@ -17,6 +17,7 @@
 
 package ch.wisv.areafiftylan.security;
 
+import ch.wisv.areafiftylan.security.authentication.AuthenticationService;
 import ch.wisv.areafiftylan.security.token.repository.AuthenticationTokenRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
@@ -42,13 +43,17 @@ class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private final RESTAuthenticationEntryPoint authenticationEntryPoint;
 
+    private AuthenticationService authenticationService;
+
     @Autowired
     public SecurityConfiguration(AuthenticationTokenRepository authenticationTokenRepository,
                                  UserDetailsService userDetailsService,
-                                 RESTAuthenticationEntryPoint authenticationEntryPoint) {
+                                 RESTAuthenticationEntryPoint authenticationEntryPoint,
+                                 AuthenticationService authenticationService) {
         this.authenticationTokenRepository = authenticationTokenRepository;
         this.userDetailsService = userDetailsService;
         this.authenticationEntryPoint = authenticationEntryPoint;
+        this.authenticationService = authenticationService;
     }
 
     /**
@@ -77,6 +82,10 @@ class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         // We use custom Authentication Tokens, making csrf redundant
         http.csrf().disable();
 
+        // Set the login point to get X-Auth-Tokens
+        http.addFilterAfter(new JsonLoginFilter(this.authenticationManagerBean(),
+                        new JsonLoginAuthenticationSuccessHandler(authenticationService)),
+                UsernamePasswordAuthenticationFilter.class);
         // Add support for Token-base authentication
         http.addFilterAfter(new TokenAuthenticationFilter(authenticationTokenRepository),
                 UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationController.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationController.java
@@ -25,7 +25,6 @@ import ch.wisv.areafiftylan.security.token.VerificationToken;
 import ch.wisv.areafiftylan.security.token.repository.PasswordResetTokenRepository;
 import ch.wisv.areafiftylan.security.token.repository.VerificationTokenRepository;
 import ch.wisv.areafiftylan.users.model.User;
-import ch.wisv.areafiftylan.users.model.UserDTO;
 import ch.wisv.areafiftylan.users.service.UserService;
 import com.google.common.base.Strings;
 import lombok.extern.log4j.Log4j2;
@@ -36,7 +35,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
@@ -73,26 +71,9 @@ public class AuthenticationController {
         this.passwordResetTokenRepository = passwordResetTokenRepository;
     }
 
-    /**
-     * This basic GET method for the /login endpoint returns a simple login form.
-     *
-     * @return Login view
-     */
-    @RequestMapping(value = "/login", method = RequestMethod.GET)
-    public ModelAndView getLoginPage() {
-        return new ModelAndView("loginForm");
-    }
-
     @RequestMapping(value = "/token", method = RequestMethod.GET)
     public ResponseEntity<?> checkSession() {
         return createResponseEntity(HttpStatus.OK, "Here's your token!");
-    }
-
-    @RequestMapping(value = "/token", method = RequestMethod.POST)
-    public ResponseEntity<?> createAuthenticationToken(@RequestBody UserDTO userDTO) {
-        String authToken = authenticationService.createNewAuthToken(userDTO.getUsername(), userDTO.getPassword());
-
-        return createResponseEntity(HttpStatus.OK, "Token successfully created", authToken);
     }
 
     @PreAuthorize("isAuthenticated()")
@@ -102,13 +83,12 @@ public class AuthenticationController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @RequestMapping(value = "/logout", method = RequestMethod.GET)
+    @RequestMapping(value = "/logout", method = RequestMethod.POST)
     public ResponseEntity<?> removeSession(@RequestHeader("X-Auth-Token") String xAuth) {
         authenticationService.removeAuthToken(xAuth);
 
         return createResponseEntity(HttpStatus.OK, "Successfully logged out");
     }
-
 
     /**
      * This method requests a passwordResetToken and sends it to the user. With this token, the user can reset his

--- a/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationService.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationService.java
@@ -19,7 +19,7 @@ package ch.wisv.areafiftylan.security.authentication;
 
 public interface AuthenticationService {
 
-    String createNewAuthToken(String username, String password);
+    String createNewAuthToken(String username);
 
     void removeAuthToken(String xAuth);
 }

--- a/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationServiceImpl.java
@@ -25,9 +25,6 @@ import ch.wisv.areafiftylan.users.model.User;
 import ch.wisv.areafiftylan.users.service.UserService;
 import com.google.common.base.Strings;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -45,18 +42,15 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     }
 
     @Override
-    public String createNewAuthToken(String username, String password) {
+    public String createNewAuthToken(String username) {
         User user = userService.getUserByUsername(username);
 
-        if (correctCredentials(user, password)) {
-            // Delete the old Token
-            authenticationTokenRepository.findByUserUsername(username).ifPresent(authenticationTokenRepository::delete);
+        // Delete the old Token
+        authenticationTokenRepository.findByUserUsername(username).ifPresent(authenticationTokenRepository::delete);
 
-            return authenticationTokenRepository.save(new AuthenticationToken(user)).getToken();
-        }
-
-        throw new AuthenticationCredentialsNotFoundException("Incorrect credentials");
+        return authenticationTokenRepository.save(new AuthenticationToken(user)).getToken();
     }
+
 
     @Override
     public void removeAuthToken(String xAuth) {
@@ -73,9 +67,5 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 
         token.revoke();
         authenticationTokenRepository.saveAndFlush(token);
-    }
-
-    private boolean correctCredentials(User user, String password) {
-        return new BCryptPasswordEncoder().matches(password, user.getPassword());
     }
 }

--- a/src/test/java/ch/wisv/areafiftylan/TokenAuthenticationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/TokenAuthenticationTest.java
@@ -60,14 +60,14 @@ public class TokenAuthenticationTest extends XAuthIntegrationTest {
         Response response = given().
         when().
             body(userDTO).contentType(ContentType.JSON).
-            post("/token");
+            post("/login");
 
         Optional<AuthenticationToken> authenticationToken =
                 authenticationTokenRepository.findByUserUsername(user.getUsername());
 
         Assert.assertTrue(authenticationToken.isPresent());
 
-        response.then().statusCode(HttpStatus.SC_OK).body("object", containsString(authenticationToken.get().getToken()));
+        response.then().statusCode(HttpStatus.SC_OK).header("X-Auth-Token", containsString(authenticationToken.get().getToken()));
 
     }
 
@@ -82,7 +82,7 @@ public class TokenAuthenticationTest extends XAuthIntegrationTest {
         given().
         when().
             body(userDTO).contentType(ContentType.JSON).
-            post("/token").
+            post("/login").
         then().
             statusCode(HttpStatus.SC_OK);
         //@formatter:on
@@ -94,7 +94,7 @@ public class TokenAuthenticationTest extends XAuthIntegrationTest {
         given().
         when().
             body(userDTO).contentType(ContentType.JSON).
-            post("/token").
+            post("/login").
         then().
             statusCode(HttpStatus.SC_OK);
         //@formatter:on

--- a/src/test/java/ch/wisv/areafiftylan/UserRestIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/UserRestIntegrationTest.java
@@ -21,7 +21,6 @@ import ch.wisv.areafiftylan.security.token.repository.VerificationTokenRepositor
 import ch.wisv.areafiftylan.users.model.User;
 import ch.wisv.areafiftylan.utils.TaskScheduler;
 import io.restassured.http.ContentType;
-import io.restassured.http.Header;
 import org.apache.http.HttpStatus;
 import org.junit.After;
 import org.junit.Test;
@@ -648,42 +647,6 @@ public class UserRestIntegrationTest extends XAuthIntegrationTest {
     }
 
     @Test
-    public void testChangePassword() {
-        //TODO: Move to new AuthenticationTest
-        User user = createUser();
-
-        String newPassword = "newPassword";
-        Map<String, String> passwordDTO = new HashMap<>();
-        passwordDTO.put("oldPassword", cleartextPassword);
-        passwordDTO.put("newPassword", newPassword);
-
-        //@formatter:off
-        Header xAuthTokenHeader = getXAuthTokenHeaderForUser(user);
-
-        given().
-            header(xAuthTokenHeader).
-        when().
-            body(passwordDTO).
-            contentType(ContentType.JSON).
-            put("/users/current/password").
-        then().
-            statusCode(HttpStatus.SC_OK);
-        //@formatter:on
-
-        removeXAuthToken(xAuthTokenHeader);
-
-        //@formatter:off
-        given().
-            header(getXAuthTokenHeaderForUser(user, newPassword)).
-        when().
-            get("/users/current").
-        then().statusCode(HttpStatus.SC_OK).
-            body("username", equalTo(user.getUsername())).
-            body("authorities", hasItem("ROLE_USER"));
-        //@formatter:on
-    }
-
-    @Test
     public void testChangePasswordWrongOldPassword() {
         //TODO: Move to new AuthenticationTest
         User user = createUser();
@@ -778,7 +741,7 @@ public class UserRestIntegrationTest extends XAuthIntegrationTest {
         User user = createUser();
         //@formatter:off
         given().
-            header(getXAuthTokenHeaderForUser(user.getUsername().toUpperCase(), cleartextPassword)).
+            header(getXAuthTokenHeaderForUser(user.getUsername().toUpperCase())).
         when().
             get("/users/current").
         then().statusCode(HttpStatus.SC_OK).

--- a/src/test/java/ch/wisv/areafiftylan/XAuthIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/XAuthIntegrationTest.java
@@ -142,15 +142,11 @@ public abstract class XAuthIntegrationTest {
     }
 
     protected Header getXAuthTokenHeaderForUser(User user) {
-        return getXAuthTokenHeaderForUser(user, cleartextPassword);
+        return getXAuthTokenHeaderForUser(user.getUsername());
     }
 
-    protected Header getXAuthTokenHeaderForUser(User user, String password) {
-        return getXAuthTokenHeaderForUser(user.getUsername(), password);
-    }
-
-    protected Header getXAuthTokenHeaderForUser(String username, String password) {
-        String authToken = authenticationService.createNewAuthToken(username, password);
+    protected Header getXAuthTokenHeaderForUser(String username) {
+        String authToken = authenticationService.createNewAuthToken(username);
         return new Header("X-Auth-Token", authToken);
     }
 


### PR DESCRIPTION
With the transition to Auth Tokens, we started using some super simple authentication. We ran into some problems like #329. This PR implements an extension of the old authentication method, with some custom json parsing. Should be more secure then our own fiddling.

Changes for frontend:
Login at `/login` instead of `/token`
Token can be found in the `X-Auth-Token` header, not in the body

Fixes #329