### PR TITLE
Add endpoint for retrieval of PaymentURL for a pending order

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/products/controller/OrderRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/controller/OrderRestController.java
@@ -125,8 +125,7 @@ public class OrderRestController {
     @RequestMapping(value = "/orders/{orderId}/{ticketId}", method = RequestMethod.DELETE)
     @JsonView(View.OrderOverview.class)
     public ResponseEntity<?> removeFromOrder(@PathVariable Long orderId, @PathVariable Long ticketId) {
-        Order modifiedOrder = orderService
-                .removeTicketFromOrder(orderId, ticketId);
+        Order modifiedOrder = orderService.removeTicketFromOrder(orderId, ticketId);
         return createResponseEntity(HttpStatus.OK, "Ticket successfully removed from Order", modifiedOrder);
     }
 
@@ -160,6 +159,23 @@ public class OrderRestController {
     @RequestMapping(value = "/orders/{orderId}/checkout", method = RequestMethod.POST)
     public ResponseEntity<?> payOrder(@PathVariable Long orderId) throws URISyntaxException {
         String paymentUrl = orderService.requestPayment(orderId);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(new URI(paymentUrl));
+
+        return createResponseEntity(HttpStatus.OK, headers, "Please go to the url to finish your payment", paymentUrl);
+    }
+
+    /**
+     * This method gets the paymentURL for an order that was already registered at the paymentprovider.
+     *
+     * @param orderId The order to be continued
+     *
+     * @return The paymentURL from the paymentprovider
+     */
+    @PreAuthorize("@currentUserServiceImpl.canAccessOrder(principal, #orderId)")
+    @GetMapping(value = "/orders/{orderId}/url")
+    public ResponseEntity<?> getPaymentURL(@PathVariable Long orderId) throws URISyntaxException {
+        String paymentUrl = orderService.getPaymentUrl(orderId);
         HttpHeaders headers = new HttpHeaders();
         headers.setLocation(new URI(paymentUrl));
 

--- a/src/main/java/ch/wisv/areafiftylan/products/service/MolliePaymentService.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/MolliePaymentService.java
@@ -104,8 +104,6 @@ public class MolliePaymentService implements PaymentService {
         try {
             // Request a payment from Mollie
             ResponseOrError<Payment> molliePaymentStatus = mollie.payments().get(orderReference);
-            //            ResponseOrError<PaymentStatus> molliePaymentStatus = mollie.getPaymentStatus(apiKey,
-            // orderReference);
 
             // If the request was a success, we can update the order
             if (molliePaymentStatus.getSuccess()) {
@@ -143,6 +141,23 @@ public class MolliePaymentService implements PaymentService {
             // This indicates the HttpClient encountered some error
             throw new PaymentServiceConnectionException(e.getMessage());
         }
+    }
+
+    @Override
+    public String getPaymentUrl(String orderReference) {
+        try {
+            ResponseOrError<Payment> paymentResponseOrError = mollie.payments().get(orderReference);
+
+            if (paymentResponseOrError.getSuccess()) {
+                return paymentResponseOrError.getData().getLinks().getPaymentUrl();
+            } else {
+                handleMollieError(paymentResponseOrError);
+            }
+
+        } catch (IOException e) {
+            throw new PaymentServiceConnectionException(e.getMessage());
+        }
+        throw new PaymentException("Can't retrieve Payment URL for Order " + orderReference);
     }
 
     private void handleMollieError(ResponseOrError<?> mollieResponseWithError) {

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderService.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderService.java
@@ -87,4 +87,6 @@ public interface OrderService {
      * @return A collection of TicketInformation objects
      */
     Collection<TicketInformationResponse> getAvailableTickets();
+
+    String getPaymentUrl(Long orderId);
 }

--- a/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/OrderServiceImpl.java
@@ -262,4 +262,13 @@ public class OrderServiceImpl implements OrderService {
         }
         return ticketInfo;
     }
+
+    @Override
+    public String getPaymentUrl(Long orderId) {
+        Order order = getOrderById(orderId);
+        if(!order.getStatus().equals(OrderStatus.PENDING)){
+            throw new ImmutableOrderException(orderId);
+        }
+        return paymentService.getPaymentUrl(order.getReference());
+    }
 }

--- a/src/main/java/ch/wisv/areafiftylan/products/service/PaymentService.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/service/PaymentService.java
@@ -38,4 +38,6 @@ public interface PaymentService {
      * @return The updated Order
      */
     Order updateStatus(String orderReference);
+
+    String getPaymentUrl(String orderReference);
 }

--- a/src/test/java/ch/wisv/areafiftylan/ApplicationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/ApplicationTest.java
@@ -73,6 +73,10 @@ public class ApplicationTest {
             return "http://paymentURL.com";
 
         });
+
+        Mockito.when(mockMolliePaymentService.getPaymentUrl(Mockito.anyString()))
+                .thenReturn("http://newpaymentURL.com");
+
         return mockMolliePaymentService;
     }
 

--- a/src/test/java/ch/wisv/areafiftylan/OrderRestIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/OrderRestIntegrationTest.java
@@ -639,4 +639,22 @@ public class OrderRestIntegrationTest extends XAuthIntegrationTest {
             header("Location", containsString("http://newpaymentURL.com"));
         //@formatter:on
     }
+
+    @Test
+    public void testGetPaymentUrlOrderAssigned() {
+        User user = createUser();
+        Order order = addOrderForUser(user);
+        order.setStatus(OrderStatus.ASSIGNED);
+        orderRepository.save(order);
+
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(user)).
+        when().
+            get(ORDER_ENDPOINT + order.getId() + "/url").
+        then().
+            statusCode(HttpStatus.SC_CONFLICT).
+            body("message", equalTo("Operation on Order " + order.getId() + " not permitted"));
+        //@formatter:on
+    }
 }

--- a/src/test/java/ch/wisv/areafiftylan/OrderRestIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/OrderRestIntegrationTest.java
@@ -19,6 +19,7 @@ package ch.wisv.areafiftylan;
 
 import ch.wisv.areafiftylan.products.model.Ticket;
 import ch.wisv.areafiftylan.products.model.order.Order;
+import ch.wisv.areafiftylan.products.model.order.OrderStatus;
 import ch.wisv.areafiftylan.products.service.repository.OrderRepository;
 import ch.wisv.areafiftylan.products.service.repository.TicketRepository;
 import ch.wisv.areafiftylan.users.model.User;
@@ -618,6 +619,24 @@ public class OrderRestIntegrationTest extends XAuthIntegrationTest {
         then().
             statusCode(HttpStatus.SC_OK).
             body("object", is(nullValue()));
+        //@formatter:on
+    }
+
+    @Test
+    public void testGetPaymentUrl() {
+        User user = createUser();
+        Order order = addOrderForUser(user);
+        order.setStatus(OrderStatus.PENDING);
+        orderRepository.save(order);
+
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(user)).
+        when().
+            get(ORDER_ENDPOINT + order.getId() + "/url").
+        then().
+            statusCode(HttpStatus.SC_OK).
+            header("Location", containsString("http://newpaymentURL.com"));
         //@formatter:on
     }
 }

--- a/src/test/java/ch/wisv/areafiftylan/products/service/OrderServiceTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/products/service/OrderServiceTest.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -694,5 +695,33 @@ public class OrderServiceTest extends ServiceTest {
         verify(mailService, times(1)).sendOrderConfirmation(any(Order.class));
 
         reset(paymentService);
+    }
+
+    @Test
+    public void getPaymentURLPendingOrder() {
+        User user = persistUser();
+        Order order = new Order(user);
+        order.setReference("getPaymentURLPendingOrder");
+        order.setStatus(OrderStatus.PENDING);
+
+        order = testEntityManager.persist(order);
+
+        given(paymentService.getPaymentUrl(order.getReference())).willReturn("https://newpaymenturl.com");
+
+        String paymentUrl = orderService.getPaymentUrl(order.getId());
+
+        assertThat(paymentUrl).isEqualTo("https://newpaymenturl.com");
+    }
+
+    @Test
+    public void getPaymentURLAssignedOrder() {
+        thrown.expect(ImmutableOrderException.class);
+        User user = persistUser();
+        Order order = new Order(user);
+        order.setReference("getPaymentURLPendingOrder");
+
+        order = testEntityManager.persist(order);
+
+        orderService.getPaymentUrl(order.getId());
     }
 }


### PR DESCRIPTION
This PR adds an endpoint to get the payment URL for pending orders. This can be used to continue an order that was previously started, but interrupted. Only works for Orders that already started (=PENDING). Other others either need to be checked out first, or are already cancelled. 

Fixes #356 