### PR TITLE
Change to dateTime format for the default logs

### DIFF
--- a/src/main/resources/log4j2-prod.xml
+++ b/src/main/resources/log4j2-prod.xml
@@ -18,7 +18,7 @@
 
 <Configuration status="WARN">
     <Properties>
-        <Property name="PATTERN">%d{HH:mm:ss.SSS} [%t] %-5level %class.%method - %msg%n</Property>
+        <Property name="PATTERN">%d{DEFAULT} [%t] %-5level %class.%method - %msg%n</Property>
     </Properties>
     <CustomLevels>
         <CustomLevel name="A5L" intLevel="350" />

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -18,7 +18,7 @@
 
 <Configuration status="WARN">
     <Properties>
-        <Property name="PATTERN">%clr{%d{yyyy-MM-dd HH:mm:ss.SSS}}{faint} %clr{%5p} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{yellow} %clr{:}{faint} %m%n%wEx</Property>
+        <Property name="PATTERN">%clr{%d{DEFAULT}}{faint} %clr{%5p} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{yellow} %clr{:}{faint} %m%n%wEx</Property>
     </Properties>
     <CustomLevels>
         <CustomLevel name="A5L" intLevel="350" />


### PR DESCRIPTION
Date formats are now changed to incorporate the date and not only the time of the event.

![image](https://cloud.githubusercontent.com/assets/9624753/22883718/c39dd43a-f1f1-11e6-85b7-8797c95cbbb6.png)