### PR TITLE
Continue filter chain after login

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/security/JsonLoginFilter.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/JsonLoginFilter.java
@@ -43,7 +43,8 @@ public class JsonLoginFilter extends UsernamePasswordAuthenticationFilter {
     private AuthenticationManager authenticationManager;
     private JsonLoginAuthenticationSuccessHandler successHandler;
 
-    public JsonLoginFilter(AuthenticationManager authenticationManager, JsonLoginAuthenticationSuccessHandler successHandler) {
+    public JsonLoginFilter(AuthenticationManager authenticationManager,
+                           JsonLoginAuthenticationSuccessHandler successHandler) {
         super();
         this.authenticationManager = authenticationManager;
         this.successHandler = successHandler;
@@ -60,7 +61,6 @@ public class JsonLoginFilter extends UsernamePasswordAuthenticationFilter {
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
                                             Authentication authResult) throws IOException, ServletException {
         successHandler.onAuthenticationSuccess(request, response, authResult);
-        chain.doFilter(request, response);
     }
 
     private UserDTO getUserDTO(HttpServletRequest request) {

--- a/src/main/java/ch/wisv/areafiftylan/security/JsonLoginFilter.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/JsonLoginFilter.java
@@ -60,6 +60,7 @@ public class JsonLoginFilter extends UsernamePasswordAuthenticationFilter {
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
                                             Authentication authResult) throws IOException, ServletException {
         successHandler.onAuthenticationSuccess(request, response, authResult);
+        chain.doFilter(request, response);
     }
 
     private UserDTO getUserDTO(HttpServletRequest request) {

--- a/src/main/java/ch/wisv/areafiftylan/security/SecurityConfiguration.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/SecurityConfiguration.java
@@ -82,6 +82,8 @@ class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         // We use custom Authentication Tokens, making csrf redundant
         http.csrf().disable();
 
+        // Add the default headers first
+        http.addFilterBefore(new CORSFilter(), JsonLoginFilter.class);
         // Set the login point to get X-Auth-Tokens
         http.addFilterAfter(new JsonLoginFilter(this.authenticationManagerBean(),
                         new JsonLoginAuthenticationSuccessHandler(authenticationService)),

--- a/src/test/java/ch/wisv/areafiftylan/TokenAuthenticationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/TokenAuthenticationTest.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.any;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -59,6 +58,7 @@ public class TokenAuthenticationTest extends XAuthIntegrationTest {
 
         //@formatter:off
         Response response = given().
+                header("Origin", "rest-assured").
         when().
             body(userDTO).contentType(ContentType.JSON).
             post("/login");
@@ -71,7 +71,7 @@ public class TokenAuthenticationTest extends XAuthIntegrationTest {
         response.then().
                 statusCode(HttpStatus.SC_OK).
                 header("X-Auth-Token", containsString(authenticationToken.get().getToken())).
-                header("Access-Control-Allow-Origin", any(String.class));
+                header("Access-Control-Allow-Origin", "rest-assured");
         //@formatter:on
     }
 

--- a/src/test/java/ch/wisv/areafiftylan/TokenAuthenticationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/TokenAuthenticationTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.any;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -67,8 +68,11 @@ public class TokenAuthenticationTest extends XAuthIntegrationTest {
 
         Assert.assertTrue(authenticationToken.isPresent());
 
-        response.then().statusCode(HttpStatus.SC_OK).header("X-Auth-Token", containsString(authenticationToken.get().getToken()));
-
+        response.then().
+                statusCode(HttpStatus.SC_OK).
+                header("X-Auth-Token", containsString(authenticationToken.get().getToken())).
+                header("Access-Control-Allow-Origin", any(String.class));
+        //@formatter:on
     }
 
     @Test


### PR DESCRIPTION
We had some CORS errors, which was because the filter chain was interrupted on successful authentication. This fix allows the filter chain to continue, so the request passes the CORSFilter, adding some required headers. 