### PR TITLE
Add Auth header to allowed headers

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/security/CORSFilter.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/CORSFilter.java
@@ -18,34 +18,30 @@
 package ch.wisv.areafiftylan.security;
 
 import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
 
-import javax.servlet.*;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @Component
-public class CORSFilter implements Filter {
+public class CORSFilter extends OncePerRequestFilter {
 
     @Override
-    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
-            throws IOException, ServletException {
-
-        HttpServletRequest request = (HttpServletRequest) req;
-        HttpServletResponse response = (HttpServletResponse) res;
-
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
         response.setHeader("Access-Control-Allow-Origin", request.getHeader("Origin"));
-        response.setHeader("Access-Control-Allow-Credentials", "true");
-        response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE, PUT, PATCH");
+        response.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
         response.setHeader("Access-Control-Max-Age", "3600");
-        response.setHeader("Access-Control-Allow-Headers", "Content-Type, Accept, X-Requested-With, remember-me");
-        response.setHeader("Access-Control-Expose-Headers", "X-Auth-Token");
-
-        chain.doFilter(req, res);
-    }
-
-    @Override
-    public void init(FilterConfig filterConfig) {
+        response.setHeader("Access-Control-Allow-Headers", "X-Auth-Token, Accept, Content-Type, Origin");
+        response.addHeader("Access-Control-Expose-Headers", "X-Auth-Token");
+        if ("OPTIONS".equals(request.getMethod())) {
+            response.setStatus(HttpServletResponse.SC_OK);
+        } else {
+            filterChain.doFilter(request, response);
+        }
     }
 
     @Override

--- a/src/main/java/ch/wisv/areafiftylan/security/CORSFilter.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/CORSFilter.java
@@ -39,6 +39,7 @@ public class CORSFilter implements Filter {
         response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE, PUT, PATCH");
         response.setHeader("Access-Control-Max-Age", "3600");
         response.setHeader("Access-Control-Allow-Headers", "Content-Type, Accept, X-Requested-With, remember-me");
+        response.setHeader("Access-Control-Expose-Headers", "X-Auth-Token");
 
         chain.doFilter(req, res);
     }


### PR DESCRIPTION
Fixes the `Refused to get unsafe header "X-Auth-Token"` error for cross origin requests. 