### PR TITLE
Username leaks & password validation

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationController.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationController.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -106,13 +107,15 @@ public class AuthenticationController {
 
         log.log(Level.getLevel("A5L"), "Requesting password reset on email {}.", username);
 
-        User user = userService.getUserByUsername(username);
+        try {
+            User user = userService.getUserByUsername(username);
+            userService.requestResetPassword(user, request);
+            log.log(Level.getLevel("A5L"), "Successfully requested password reset on email {}.", username);
+        } catch (UsernameNotFoundException e) {
+            log.warn("Password for {} can't be reset, User doesn't exist");
+        }
 
-        userService.requestResetPassword(user, request);
-
-        log.log(Level.getLevel("A5L"), "Successfully requested password reset on email {}.", username);
-
-        return createResponseEntity(HttpStatus.OK, "Password reset link sent to " + username);
+        return createResponseEntity(HttpStatus.OK, "If you're registered, a password reset link has been sent to " + username);
     }
 
     /**

--- a/src/main/java/ch/wisv/areafiftylan/users/controller/UserRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/users/controller/UserRestController.java
@@ -176,22 +176,9 @@ public class UserRestController {
         return seatService.getSeatsByUsername(user.getUsername());
     }
 
-    /**
-     * Checks for the availability of a username. Returns false when another user is already registered with this
-     * username.
-     *
-     * @param username The username to be checked.
-     *
-     * @return Whether this username has already been registered.
-     */
-    @RequestMapping(value = "/checkUsername", method = RequestMethod.GET)
-    public Boolean checkUsernameExists(@RequestParam String username) {
-        return userService.checkUsernameAvailable(username);
-    }
-
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<?> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
-        return createResponseEntity(HttpStatus.CONFLICT, "Username or Email already taken!");
+        return createResponseEntity(HttpStatus.CONFLICT, "Email is already in use");
     }
 
     @ExceptionHandler(ConstraintViolationException.class)

--- a/src/main/java/ch/wisv/areafiftylan/users/service/UserServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/users/service/UserServiceImpl.java
@@ -218,6 +218,9 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     @Override
     public void resetPassword(Long userId, String password) {
         User user = userRepository.findOne(userId);
+        if (Strings.isNullOrEmpty(password)) {
+            throw new IllegalArgumentException("Password can't be empty");
+        }
         // The token is being checked in the authentication, so just set the password here
         user.setPasswordHash(new BCryptPasswordEncoder().encode(password));
         userRepository.saveAndFlush(user);


### PR DESCRIPTION
Fixes #404 
Fixes #403 

This PR removes some existing username leaks and checks if a newly reset password isn't empty to prevent users from locking themselves out due to required fields and such.