### PR TITLE
Correct captain removal

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/security/authentication/CurrentUserServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/authentication/CurrentUserServiceImpl.java
@@ -119,11 +119,6 @@ public class CurrentUserServiceImpl implements CurrentUserService {
             User user = (User) principal;
             Team team = teamService.getTeamById(teamId);
 
-            // You can't remove a Team Captain
-            if (team.getCaptain().getEmail().equals(email)) {
-                return false;
-            }
-
             // You can remove people from a Team if you're Admin, the Team Captain, or if you want to remove yourself
             return  isTeamCaptain(team, user) ||
                     isAdmin(user) ||

--- a/src/main/java/ch/wisv/areafiftylan/teams/service/TeamServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/teams/service/TeamServiceImpl.java
@@ -30,6 +30,7 @@ import ch.wisv.areafiftylan.users.service.UserService;
 import ch.wisv.areafiftylan.utils.mail.MailService;
 import com.google.common.base.Strings;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.method.P;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
@@ -206,14 +207,16 @@ public class TeamServiceImpl implements TeamService {
     public boolean removeMember(Long teamId, String email) {
         Team team = getTeamById(teamId);
         User user = userService.getUserByEmail(email);
+
         if (team.getCaptain().equals(user)) {
-            return false;
-        }
-        boolean success = team.removeMember(user);
-        if (success) {
+            if (team.getSize() > 1) {
+                return false;
+            }
+            delete(team.getId());
+        } else {
+            team.removeMember(user);
             teamRepository.saveAndFlush(team);
         }
-        return success;
-
+        return true;
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/teams/service/TeamServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/teams/service/TeamServiceImpl.java
@@ -30,7 +30,6 @@ import ch.wisv.areafiftylan.users.service.UserService;
 import ch.wisv.areafiftylan.utils.mail.MailService;
 import com.google.common.base.Strings;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.method.P;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;

--- a/src/test/java/ch/wisv/areafiftylan/integration/TeamRestIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/integration/TeamRestIntegrationTest.java
@@ -30,7 +30,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import javax.validation.constraints.AssertTrue;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;


### PR DESCRIPTION
The delete team method was not useful or logical. By allowing this, the flow is much more logical.