### PR TITLE
Add icon groups to the testdatarunner

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/utils/TestDataRunner.java
+++ b/src/main/java/ch/wisv/areafiftylan/utils/TestDataRunner.java
@@ -215,13 +215,13 @@ public class TestDataRunner implements CommandLineRunner {
         seatService.reserveSeat("B", 1, ticketNormal.getId(), false);
         //endregion Seat
         //region Web Data
-        committeeMember(1L, "Chairman", "Mark Rutte", "group");
-        committeeMember(2L, "Secretary", "Lodewijk Asscher", "male");
-        committeeMember(3L, "Treasurer", "Jeroen Dijsselbloem", "money");
-        committeeMember(4L, "Commissioner of Promo", "Frans Timmermans", "bullhorn");
-        committeeMember(5L, "Commissioner of Logistics", "Melanie Schultz", "truck");
-        committeeMember(6L, "Commissioner of Systems", "Klaas Dijkhoff", "cogs");
-        committeeMember(7L, "Qualitate Qua", "Ivo Opstelten", "heart");
+        committeeMember(1L, "Chairman", "Mark Rutte", "icons:gavel");
+        committeeMember(2L, "Secretary", "Lodewijk Asscher", "icons:assignment");
+        committeeMember(3L, "Treasurer", "Jeroen Dijsselbloem", "editor:attach-money");
+        committeeMember(4L, "Commissioner of Promo", "Frans Timmermans", "social:group");
+        committeeMember(5L, "Commissioner of Logistics", "Melanie Schultz", "maps:local-shipping");
+        committeeMember(6L, "Commissioner of Systems", "Klaas Dijkhoff", "hardware:phonelink");
+        committeeMember(7L, "Qualitate Qua", "Ivo Opstelten", "communication:live-help");
 
         faqpair("What the fox say?", "Ring-ding-ding-ding-dingeringeding!");
         faqpair("What do you get if you multiply six by nine?", "42");


### PR DESCRIPTION
The groups are required, otherwise polymer does not know where the icons come from.