### PR TITLE
Remove getUsername from User view

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/users/model/User.java
+++ b/src/main/java/ch/wisv/areafiftylan/users/model/User.java
@@ -80,8 +80,9 @@ public class User implements Serializable, UserDetails {
     @JsonIgnore
     private boolean enabled = true;
 
-    // This method is created to allow logging is using the email field
+    // This method is created to allow logging in using the email field
     @Override
+    @JsonIgnore
     public String getUsername() {
         return email;
     }


### PR DESCRIPTION
Since we moved to the new login with the email field, the `getUsername` was still included in the `User` json view, this doesn't add anything but confusion, since the field is literally the same as the `email` field.