### PR TITLE
Scheduled banners

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/exception/BannerNotFoundException.java
+++ b/src/main/java/ch/wisv/areafiftylan/exception/BannerNotFoundException.java
@@ -1,0 +1,9 @@
+package ch.wisv.areafiftylan.exception;
+
+public class BannerNotFoundException extends AreaFiftyLANException {
+
+    public BannerNotFoundException() {
+        super("Could not find a banner that is scheduled for now.");
+    }
+
+}

--- a/src/main/java/ch/wisv/areafiftylan/exception/ConflictingDateRangeException.java
+++ b/src/main/java/ch/wisv/areafiftylan/exception/ConflictingDateRangeException.java
@@ -2,5 +2,5 @@ package ch.wisv.areafiftylan.exception;
 
 public class ConflictingDateRangeException extends AreaFiftyLANException {
 
-    public ConflictingDateRangeException() { super("An entity covering (a part of) the given date range already exists"); }
+    public ConflictingDateRangeException() { super("An entity covering the given date range already exists"); }
 }

--- a/src/main/java/ch/wisv/areafiftylan/exception/ConflictingDateRangeException.java
+++ b/src/main/java/ch/wisv/areafiftylan/exception/ConflictingDateRangeException.java
@@ -1,0 +1,6 @@
+package ch.wisv.areafiftylan.exception;
+
+public class ConflictingDateRangeException extends AreaFiftyLANException {
+
+    public ConflictingDateRangeException() { super("An entity covering (a part of) the given date range already exists"); }
+}

--- a/src/main/java/ch/wisv/areafiftylan/utils/TestDataRunner.java
+++ b/src/main/java/ch/wisv/areafiftylan/utils/TestDataRunner.java
@@ -223,10 +223,10 @@ public class TestDataRunner implements CommandLineRunner {
         Date winterBreakStart = Date.valueOf("2017-12-23");
         Date winterBreakEnd = Date.valueOf("2018-01-07");
         String winterBreak = "Enjoy the winter break! AreaFiftyLAN isn't far from happening!";
-        Date soonAnnouncementStart = Date.valueOf("2017-02-03");
+        Date soonAnnouncementStart = Date.valueOf("2018-02-03");
         Date soonAnnouncementEnd = Date.valueOf("2018-02-28");
         String soonAnnouncement = "AreaFiftyLAN starts in less than a month! Make sure to get your tickets!";
-        Date soldOutStart = Date.valueOf("2017-03-01");
+        Date soldOutStart = Date.valueOf("2018-03-01");
         Date soldOutEnd = Date.valueOf("2018-03-08");
         String soldOut = "Tickets are sold out!";
         banner(winterBreak, winterBreakStart, winterBreakEnd);

--- a/src/main/java/ch/wisv/areafiftylan/utils/TestDataRunner.java
+++ b/src/main/java/ch/wisv/areafiftylan/utils/TestDataRunner.java
@@ -36,6 +36,8 @@ import ch.wisv.areafiftylan.users.model.Gender;
 import ch.wisv.areafiftylan.users.model.Role;
 import ch.wisv.areafiftylan.users.model.User;
 import ch.wisv.areafiftylan.users.service.UserRepository;
+import ch.wisv.areafiftylan.web.banner.model.Banner;
+import ch.wisv.areafiftylan.web.banner.service.BannerRepository;
 import ch.wisv.areafiftylan.web.committee.model.CommitteeMember;
 import ch.wisv.areafiftylan.web.committee.service.CommitteeRepository;
 import ch.wisv.areafiftylan.web.faq.model.FaqPair;
@@ -52,6 +54,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
+import java.sql.Date;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -71,6 +74,7 @@ public class TestDataRunner implements CommandLineRunner {
     private final PossibleConsumptionsRepository consumptionsRepository;
     private final ConsumptionService consumptionService;
 
+    private final BannerRepository bannerRepository;
     private final CommitteeRepository committeeRepository;
     private final FaqRepository faqRepository;
     private final SponsorRepository sponsorRepository;
@@ -81,7 +85,7 @@ public class TestDataRunner implements CommandLineRunner {
                           TeamRepository teamRepository, SeatService seatService,
                           TicketOptionRepository ticketOptionRepository, TicketTypeRepository ticketTypeRepository,
                           RFIDLinkRepository rfidLinkRepository, PossibleConsumptionsRepository consumptionsRepository,
-                          ConsumptionService consumptionService, CommitteeRepository committeeRepository,
+                          ConsumptionService consumptionService, BannerRepository bannerRepository, CommitteeRepository committeeRepository,
                           FaqRepository faqRepository, SponsorRepository sponsorRepository,
                           TournamentRepository tournamentRepository) {
         this.accountRepository = accountRepository;
@@ -93,6 +97,7 @@ public class TestDataRunner implements CommandLineRunner {
         this.rfidLinkRepository = rfidLinkRepository;
         this.consumptionsRepository = consumptionsRepository;
         this.consumptionService = consumptionService;
+        this.bannerRepository = bannerRepository;
         this.committeeRepository = committeeRepository;
         this.faqRepository = faqRepository;
         this.sponsorRepository = sponsorRepository;
@@ -214,6 +219,20 @@ public class TestDataRunner implements CommandLineRunner {
         seatService.reserveSeat("A", 2, ticketCaptain.getId(), false);
         seatService.reserveSeat("B", 1, ticketNormal.getId(), false);
         //endregion Seat
+        //region Banner
+        Date winterBreakStart = Date.valueOf("2017-12-23");
+        Date winterBreakEnd = Date.valueOf("2018-01-07");
+        String winterBreak = "Enjoy the winter break! AreaFiftyLAN isn't far from happening!";
+        Date soonAnnouncementStart = Date.valueOf("2017-02-03");
+        Date soonAnnouncementEnd = Date.valueOf("2018-02-28");
+        String soonAnnouncement = "AreaFiftyLAN starts in less than a month! Make sure to get your tickets!";
+        Date soldOutStart = Date.valueOf("2017-03-01");
+        Date soldOutEnd = Date.valueOf("2018-03-08");
+        String soldOut = "Tickets are sold out!";
+        banner(winterBreak, winterBreakStart, winterBreakEnd);
+        banner(soonAnnouncement, soonAnnouncementStart, soonAnnouncementEnd);
+        banner(soldOut, soldOutStart, soldOutEnd);
+        //endregion Banner
         //region Web Data
         committeeMember(1L, "Chairman", "Mark Rutte", "gavel");
         committeeMember(2L, "Secretary", "Lodewijk Asscher", "chrome-reader-mode");
@@ -288,5 +307,13 @@ public class TestDataRunner implements CommandLineRunner {
         tournament.setPrizes(prizes);
         tournament.setSponsor(sponsor);
         return tournamentRepository.save(tournament);
+    }
+
+    private Banner banner(String text, Date startDate, Date endDate) {
+        Banner banner = new Banner();
+        banner.setText(text);
+        banner.setStartDate(startDate);
+        banner.setEndDate(endDate);
+        return bannerRepository.save(banner);
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/utils/db/migration/V20171208163050__add_banner.java
+++ b/src/main/java/ch/wisv/areafiftylan/utils/db/migration/V20171208163050__add_banner.java
@@ -1,0 +1,15 @@
+package ch.wisv.areafiftylan.utils.db.migration;
+
+import org.flywaydb.core.api.migration.spring.SpringJdbcMigration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class V20171208163050__add_banner implements SpringJdbcMigration {
+    @Override
+    public void migrate(JdbcTemplate jdbcTemplate) throws Exception {
+        jdbcTemplate.execute("CREATE TABLE banner (" +
+                        "id bigint NOT NULL CONSTRAINT banner_pkey PRIMARY KEY, " +
+                        "end_date DATE, " +
+                        "start_date DATE, " +
+                        "text VARCHAR(255))");
+    }
+}

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/controller/BannerController.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/controller/BannerController.java
@@ -44,7 +44,7 @@ public class BannerController {
     @GetMapping("/current")
     public ResponseEntity<?> getCurrentBanner() {
         Banner currentBanner = bannerService.getCurrentbanner();
-        return new ResponseEntity<>(currentBanner, HttpStatus.OK);
+        return createResponseEntity(HttpStatus.OK, "Found a corresponding banner.", currentBanner);
     }
 
     /**

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/controller/BannerController.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/controller/BannerController.java
@@ -1,0 +1,109 @@
+package ch.wisv.areafiftylan.web.banner.controller;
+
+import ch.wisv.areafiftylan.exception.BannerNotFoundException;
+import ch.wisv.areafiftylan.web.banner.model.Banner;
+import ch.wisv.areafiftylan.web.banner.service.BannerService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Collection;
+
+import static ch.wisv.areafiftylan.utils.ResponseEntityBuilder.createResponseEntity;
+
+@Controller
+@RequestMapping("/web/banners")
+public class BannerController {
+
+    private BannerService bannerService;
+
+    public BannerController(BannerService bannerService) {
+        this.bannerService = bannerService;
+    }
+
+    /**
+     * Get all banners in the database.
+     *
+     * @return all banners
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping
+    public Collection<Banner> getBanners() {
+        return bannerService.getAllBanners();
+    }
+
+    /**
+     * Returns a banner where the current date (date when the request was made)
+     * lies within the range of its start- and end-date.
+     *
+     * @return a banner
+     */
+    @GetMapping("/current")
+    public ResponseEntity<?> getCurrentBanner() {
+        Banner currentBanner = bannerService.getCurrentbanner();
+        return new ResponseEntity<>(currentBanner, HttpStatus.OK);
+    }
+
+    /**
+     * Adds a new banner to the database. The date-range should be valid (e.g. there shouldn't be
+     * another entity covering that range already).
+     *
+     * @param banner banner to be added
+     * @return a response-entity
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    public ResponseEntity<?> addBanner(@RequestBody Banner banner) {
+        banner = bannerService.addBanner(banner);
+        return createResponseEntity(HttpStatus.OK,
+                "Successfully created a banner with ID=" + banner.getId(), banner);
+    }
+
+    /**
+     * Updates the banner with the given Id. The date-range should be valid (e.g. there shouldn't be
+     * another entity covering that range already).
+     *
+     * @param bannerId Id of the banner to be updated
+     * @param banner   banner to be updated
+     * @return the updated banner
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/{bannerId}")
+    public Banner updateBanner(@PathVariable Long bannerId, @RequestBody Banner banner) {
+        return bannerService.update(bannerId, banner);
+    }
+
+    /**
+     * Deletes a banner with the given ID from the database and returns a response-entity.
+     *
+     * @param bannerId id of the banner to be removed
+     * @return a response-entity
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{bannerId}")
+    public ResponseEntity<?> deleteBanner(@PathVariable Long bannerId) {
+        bannerService.removeBanner(bannerId);
+        return createResponseEntity(HttpStatus.OK,
+                "Successfully removed the banner with ID=" + bannerId);
+    }
+
+    /**
+     * Deletes all banners from the database.
+     *
+     * @return a response-entity
+     */
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping
+    public ResponseEntity<?> deleteAllBanners() {
+        bannerService.deleteBanners();
+        return createResponseEntity(HttpStatus.OK,
+                "Successfully deleted all banners");
+    }
+
+    @ExceptionHandler(BannerNotFoundException.class)
+    public ResponseEntity<?> handleBannerNotFoundException(BannerNotFoundException ex) {
+        return createResponseEntity(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+}

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/controller/BannerController.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/controller/BannerController.java
@@ -75,7 +75,7 @@ public class BannerController {
     public ResponseEntity<?> updateBanner(@PathVariable Long bannerId, @RequestBody Banner banner) {
         Banner updated = bannerService.update(bannerId, banner);
         return createResponseEntity(HttpStatus.OK,
-                "Successfully updated a banner with ID=" + bannerId, updated);
+                "Successfully updated the banner with ID=" + bannerId, updated);
     }
 
     /**

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/controller/BannerController.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/controller/BannerController.java
@@ -72,8 +72,10 @@ public class BannerController {
      */
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/{bannerId}")
-    public Banner updateBanner(@PathVariable Long bannerId, @RequestBody Banner banner) {
-        return bannerService.update(bannerId, banner);
+    public ResponseEntity<?> updateBanner(@PathVariable Long bannerId, @RequestBody Banner banner) {
+        Banner updated = bannerService.update(bannerId, banner);
+        return createResponseEntity(HttpStatus.OK,
+                "Successfully updated a banner with ID=" + bannerId, updated);
     }
 
     /**

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/controller/BannerController.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/controller/BannerController.java
@@ -70,7 +70,7 @@ public class BannerController {
      * @return the updated banner
      */
     @PreAuthorize("hasRole('ADMIN')")
-    @PutMapping("/{bannerId}")
+    @PostMapping("/{bannerId}")
     public Banner updateBanner(@PathVariable Long bannerId, @RequestBody Banner banner) {
         return bannerService.update(bannerId, banner);
     }

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/controller/BannerController.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/controller/BannerController.java
@@ -30,8 +30,9 @@ public class BannerController {
      */
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping
-    public Collection<Banner> getBanners() {
-        return bannerService.getAllBanners();
+    public ResponseEntity<?> getBanners() {
+        Collection<Banner> banners = bannerService.getAllBanners();
+        return new ResponseEntity<>(banners, HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/model/Banner.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/model/Banner.java
@@ -3,7 +3,6 @@ package ch.wisv.areafiftylan.web.banner.model;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -18,7 +17,6 @@ public class Banner {
     @GeneratedValue
     private Long id;
 
-    @Column(columnDefinition = "TEXT")
     private String text;
 
     private Date startDate;

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/model/Banner.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/model/Banner.java
@@ -7,7 +7,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import java.time.LocalDate;
+import java.sql.Date;
 
 @Entity
 @Data
@@ -21,9 +21,7 @@ public class Banner {
     @Column(columnDefinition = "TEXT")
     private String text;
 
-    @Column(columnDefinition = "DATE")
-    private LocalDate startDate;
+    private Date startDate;
 
-    @Column(columnDefinition = "DATE")
-    private LocalDate endDate;
+    private Date endDate;
 }

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/model/Banner.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/model/Banner.java
@@ -1,0 +1,29 @@
+package ch.wisv.areafiftylan.web.banner.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import java.time.LocalDate;
+
+@Entity
+@Data
+@NoArgsConstructor
+public class Banner {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(columnDefinition = "TEXT")
+    private String text;
+
+    @Column(columnDefinition = "DATE")
+    private LocalDate startDate;
+
+    @Column(columnDefinition = "DATE")
+    private LocalDate endDate;
+}

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerRepository.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerRepository.java
@@ -4,13 +4,13 @@ import ch.wisv.areafiftylan.web.banner.model.Banner;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
+import java.sql.Date;
 import java.util.Optional;
 
 @Repository
 public interface BannerRepository extends JpaRepository<Banner, Long> {
 
     // [Start, End)
-    Optional<Banner> findByStartDateGreaterThanEqualAndEndDateLessThan(LocalDate dateGreater, LocalDate dateLess);
+    Optional<Banner> findByStartDateGreaterThanEqualAndEndDateLessThan(Date dateGreater, Date dateLess);
 
 }

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerRepository.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 @Repository
 public interface BannerRepository extends JpaRepository<Banner, Long> {
 
-    // [Start, End)
-    Optional<Banner> findByStartDateGreaterThanEqualAndEndDateLessThan(Date dateGreater, Date dateLess);
+    // Note that the latest inserted is returned in case of multiple results.
+    Optional<Banner> findFirstByStartDateBeforeAndEndDateAfterOrderByIdDesc(Date dateGreater, Date dateLess);
 
 }

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerRepository.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerRepository.java
@@ -11,6 +11,9 @@ import java.util.Optional;
 public interface BannerRepository extends JpaRepository<Banner, Long> {
 
     // Note that the latest inserted is returned in case of multiple results.
-    Optional<Banner> findFirstByStartDateBeforeAndEndDateAfterOrderByIdDesc(Date dateGreater, Date dateLess);
+    Optional<Banner> findFirstByStartDateLessThanEqualAndEndDateGreaterThanEqualOrderByIdDesc(Date dateGreater, Date dateLess);
 
+    Optional<Banner> findByEndDateGreaterThanEqual(Date date);
+
+    Optional<Banner> findByStartDateGreaterThanEqual(Date date);
 }

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerRepository.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerRepository.java
@@ -1,0 +1,16 @@
+package ch.wisv.areafiftylan.web.banner.service;
+
+import ch.wisv.areafiftylan.web.banner.model.Banner;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Repository
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+
+    // [Start, End)
+    Optional<Banner> findByStartDateGreaterThanEqualAndEndDateLessThan(LocalDate dateGreater, LocalDate dateLess);
+
+}

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerRepository.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerRepository.java
@@ -13,7 +13,4 @@ public interface BannerRepository extends JpaRepository<Banner, Long> {
     // Note that the latest inserted is returned in case of multiple results.
     Optional<Banner> findFirstByStartDateLessThanEqualAndEndDateGreaterThanEqualOrderByIdDesc(Date dateGreater, Date dateLess);
 
-    Optional<Banner> findByEndDateGreaterThanEqual(Date date);
-
-    Optional<Banner> findByStartDateGreaterThanEqual(Date date);
 }

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerService.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerService.java
@@ -1,0 +1,21 @@
+package ch.wisv.areafiftylan.web.banner.service;
+
+import ch.wisv.areafiftylan.web.banner.model.Banner;
+
+import java.util.Collection;
+
+public interface BannerService {
+
+    Collection<Banner> getAllBanners();
+
+    Banner getCurrentbanner();
+
+    Banner addBanner(Banner banner);
+
+    Banner update(Long bannerId, Banner banner);
+
+    void removeBanner(Long id);
+
+    void deleteBanners();
+
+}

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerServiceImpl.java
@@ -5,6 +5,7 @@ import ch.wisv.areafiftylan.exception.ConflictingDateRangeException;
 import ch.wisv.areafiftylan.web.banner.model.Banner;
 import org.springframework.stereotype.Service;
 
+import java.sql.Date;
 import java.time.LocalDate;
 import java.util.Collection;
 
@@ -24,7 +25,7 @@ public class BannerServiceImpl implements BannerService {
 
     @Override
     public Banner getCurrentbanner() {
-        LocalDate now = LocalDate.now();
+        Date now = Date.valueOf(LocalDate.now());
         return bannerRepository.findByStartDateGreaterThanEqualAndEndDateLessThan(now, now)
                 .orElseThrow(BannerNotFoundException::new);
     }
@@ -57,7 +58,7 @@ public class BannerServiceImpl implements BannerService {
         bannerRepository.deleteAll();
     }
 
-    private boolean hasConflictingDates(LocalDate startDate, LocalDate endDate) {
+    private boolean hasConflictingDates(Date startDate, Date endDate) {
         // ... WHERE new_end >= existing_start AND new_start < existing_end ;
         return bannerRepository.findByStartDateGreaterThanEqualAndEndDateLessThan(endDate, startDate).isPresent();
     }

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerServiceImpl.java
@@ -43,9 +43,6 @@ public class BannerServiceImpl implements BannerService {
         if (!bannerRepository.exists(bannerId))
             throw new BannerNotFoundException();
 
-        if (hasConflictingDates(banner))
-            throw new ConflictingDateRangeException();
-
         return bannerRepository.saveAndFlush(banner);
     }
 
@@ -61,6 +58,6 @@ public class BannerServiceImpl implements BannerService {
 
     private boolean hasConflictingDates(Banner banner) {
         // ... WHERE new_end >= existing_start AND new_start < existing_end ;
-        return bannerRepository.findFirstByStartDateBeforeAndEndDateAfterOrderByIdDesc(banner.getEndDate(), banner.getStartDate()).get().equals(banner);
+        return bannerRepository.findFirstByStartDateBeforeAndEndDateAfterOrderByIdDesc(banner.getStartDate(), banner.getEndDate()).isPresent();
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerServiceImpl.java
@@ -26,7 +26,7 @@ public class BannerServiceImpl implements BannerService {
     @Override
     public Banner getCurrentbanner() {
         Date now = Date.valueOf(LocalDate.now());
-        return bannerRepository.findFirstByStartDateBeforeAndEndDateAfterOrderByIdDesc(now, now)
+        return bannerRepository.findFirstByStartDateLessThanEqualAndEndDateGreaterThanEqualOrderByIdDesc(now, now)
                 .orElseThrow(BannerNotFoundException::new);
     }
 
@@ -58,6 +58,7 @@ public class BannerServiceImpl implements BannerService {
 
     private boolean hasConflictingDates(Banner banner) {
         // ... WHERE new_end >= existing_start AND new_start < existing_end ;
-        return bannerRepository.findFirstByStartDateBeforeAndEndDateAfterOrderByIdDesc(banner.getStartDate(), banner.getEndDate()).isPresent();
+        return bannerRepository.findByEndDateGreaterThanEqual(banner.getStartDate()).isPresent()
+                || bannerRepository.findByStartDateGreaterThanEqual(banner.getEndDate()).isPresent();
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerServiceImpl.java
@@ -1,0 +1,64 @@
+package ch.wisv.areafiftylan.web.banner.service;
+
+import ch.wisv.areafiftylan.exception.BannerNotFoundException;
+import ch.wisv.areafiftylan.exception.ConflictingDateRangeException;
+import ch.wisv.areafiftylan.web.banner.model.Banner;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Collection;
+
+@Service
+public class BannerServiceImpl implements BannerService {
+
+    private BannerRepository bannerRepository;
+
+    public BannerServiceImpl(BannerRepository bannerRepository) {
+        this.bannerRepository = bannerRepository;
+    }
+
+    @Override
+    public Collection<Banner> getAllBanners() {
+        return bannerRepository.findAll();
+    }
+
+    @Override
+    public Banner getCurrentbanner() {
+        LocalDate now = LocalDate.now();
+        return bannerRepository.findByStartDateGreaterThanEqualAndEndDateLessThan(now, now)
+                .orElseThrow(BannerNotFoundException::new);
+    }
+
+    @Override
+    public Banner addBanner(Banner banner) {
+        if (hasConflictingDates(banner.getStartDate(), banner.getEndDate()))
+            throw new ConflictingDateRangeException();
+
+        return bannerRepository.save(banner);
+    }
+
+    @Override
+    public Banner update(Long bannerId, Banner banner) {
+        Banner current = bannerRepository.findOne(bannerId);
+
+        if (hasConflictingDates(banner.getStartDate(), banner.getEndDate()))
+            throw new ConflictingDateRangeException();
+
+        return bannerRepository.saveAndFlush(current);
+    }
+
+    @Override
+    public void removeBanner(Long id) {
+        bannerRepository.delete(id);
+    }
+
+    @Override
+    public void deleteBanners() {
+        bannerRepository.deleteAll();
+    }
+
+    private boolean hasConflictingDates(LocalDate startDate, LocalDate endDate) {
+        // ... WHERE new_end >= existing_start AND new_start < existing_end ;
+        return bannerRepository.findByStartDateGreaterThanEqualAndEndDateLessThan(endDate, startDate).isPresent();
+    }
+}

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerServiceImpl.java
@@ -1,7 +1,6 @@
 package ch.wisv.areafiftylan.web.banner.service;
 
 import ch.wisv.areafiftylan.exception.BannerNotFoundException;
-import ch.wisv.areafiftylan.exception.ConflictingDateRangeException;
 import ch.wisv.areafiftylan.web.banner.model.Banner;
 import org.springframework.stereotype.Service;
 
@@ -32,9 +31,6 @@ public class BannerServiceImpl implements BannerService {
 
     @Override
     public Banner addBanner(Banner banner) {
-        if (hasConflictingDates(banner))
-            throw new ConflictingDateRangeException();
-
         return bannerRepository.save(banner);
     }
 
@@ -54,11 +50,5 @@ public class BannerServiceImpl implements BannerService {
     @Override
     public void deleteBanners() {
         bannerRepository.deleteAll();
-    }
-
-    private boolean hasConflictingDates(Banner banner) {
-        // ... WHERE new_end >= existing_start AND new_start < existing_end ;
-        return bannerRepository.findByEndDateGreaterThanEqual(banner.getStartDate()).isPresent()
-                || bannerRepository.findByStartDateGreaterThanEqual(banner.getEndDate()).isPresent();
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/web/banner/service/BannerServiceImpl.java
@@ -36,8 +36,9 @@ public class BannerServiceImpl implements BannerService {
 
     @Override
     public Banner update(Long bannerId, Banner banner) {
-        if (!bannerRepository.exists(bannerId))
+        if (!bannerRepository.exists(bannerId)) {
             throw new BannerNotFoundException();
+        }
 
         return bannerRepository.saveAndFlush(banner);
     }

--- a/src/test/java/ch/wisv/areafiftylan/integration/WebBannerIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/integration/WebBannerIntegrationTest.java
@@ -58,7 +58,7 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
 
     //region GET all banners
     @Test
-    public void testGetBannersWithoutPermissions() {
+    public void testGetBannersAsUser() {
         //@formatter:off
         given().
             header(getXAuthTokenHeaderForUser(user)).
@@ -71,7 +71,7 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
     }
 
     @Test
-    public void testGetBannerWithPermissions() throws JsonProcessingException {
+    public void testGetBannerAsAdmin() throws JsonProcessingException {
         String expected = mapper.writeValueAsString(banners);
 
         //@formatter:off
@@ -128,7 +128,7 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
     //endregion
     //region POST add banner
     @Test
-    public void testAddBannerWithoutPermissions() {
+    public void testAddBannerAsUser() {
         //@formatter:off
         given().
             header(getXAuthTokenHeaderForUser(user)).
@@ -143,7 +143,7 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
     }
 
     @Test
-    public void testAddBannerWithPermissions() {
+    public void testAddBannerAsAdmin() {
         int oldSize = bannerRepository.findAll().size();
 
         Banner newBanner = new Banner();
@@ -167,7 +167,7 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
     //endregion
     //region POST update banner
     @Test
-    public void testUpdateBannerWithoutPermissions() {
+    public void testUpdateBannerAsUser() {
         //@formatter:off
         given().
             header(getXAuthTokenHeaderForUser(user)).
@@ -182,7 +182,7 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
     }
 
     @Test
-    public void testUpdateBannerWithPermissions() {
+    public void testUpdateBannerAsAdmin() {
         Banner banner = bannerRepository.findAll().get(0);
         banner.setText("Updated text");
         System.out.println(banner);
@@ -218,7 +218,7 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
     //endregion
     //region DELETE banner
     @Test
-    public void testDeleteBannerWithoutPermissions() {
+    public void testDeleteBannerAsUser() {
         //@formatter:off
         given().
             header(getXAuthTokenHeaderForUser(user)).
@@ -231,7 +231,7 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
     }
 
     @Test
-    public void testDeleteBannerWithPermissions() {
+    public void testDeleteBannerAsAdmin() {
         Long id = bannerRepository.findAll().get(0).getId();
         //@formatter:off
         given().
@@ -248,7 +248,7 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
     //region DELETE all banners
 
     @Test
-    public void testDeleteAllBannersWithoutPermissions() {
+    public void testDeleteAllBannersAsUser() {
         //@formatter:off
         given().
             header(getXAuthTokenHeaderForUser(user)).
@@ -261,7 +261,7 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
     }
 
     @Test
-    public void testDeleteAllBannersWithPermissions() {
+    public void testDeleteAllBannersAsAdmin() {
         //@formatter:off
         given().
             header(getXAuthTokenHeaderForUser(admin)).

--- a/src/test/java/ch/wisv/areafiftylan/integration/WebBannerIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/integration/WebBannerIntegrationTest.java
@@ -1,0 +1,262 @@
+package ch.wisv.areafiftylan.integration;
+
+import ch.wisv.areafiftylan.users.model.User;
+import ch.wisv.areafiftylan.web.banner.model.Banner;
+import ch.wisv.areafiftylan.web.banner.service.BannerRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.http.ContentType;
+import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class WebBannerIntegrationTest extends XAuthIntegrationTest {
+
+    @Autowired
+    private BannerRepository bannerRepository;
+
+    private static final String BANNER_ENDPOINT = "/web/banners/";
+
+    private Banner banner;
+    private Collection<Banner> banners;
+    private User user;
+    private User admin;
+
+    private ObjectMapper mapper;
+
+    @Before
+    public void setUp() {
+        banner = new Banner();
+        banners = new ArrayList<>();
+        banner.setText("AreaFiftyLAN starts in less than a month! Make sure to get your tickets!");
+        banner.setStartDate(Date.valueOf("2017-02-03"));
+        banner.setEndDate(Date.valueOf("2018-02-28"));
+        banners.add(bannerRepository.save(banner));
+
+        user = createUser();
+        admin = createAdmin();
+
+        mapper = new ObjectMapper();
+    }
+
+    @After
+    public void cleanUpBanners() {
+        bannerRepository.deleteAll();
+    }
+
+    //region GET all banners
+    @Test
+    public void testGetBannersWithoutPermissions() {
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(user)).
+        when().
+            get(BANNER_ENDPOINT).
+        then().
+            statusCode(HttpStatus.SC_FORBIDDEN).
+            body("message", equalTo("Access denied"));
+        //@formatter:on
+    }
+
+    @Test
+    public void testGetBannerWithPermissions() throws JsonProcessingException {
+        String expected = mapper.writeValueAsString(banners);
+
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(admin)).
+        when().
+            get(BANNER_ENDPOINT).
+        then().
+            statusCode(HttpStatus.SC_OK).
+            body(equalTo(expected));
+        //@formatter:on
+    }
+
+    //endregion
+    //region GET current banner
+    @Test
+    public void testGetCurrentBanner() throws JsonProcessingException {
+        LocalDate lastWeek = LocalDate.now().minusWeeks(1);
+        LocalDate nextWeek = LocalDate.now().plusWeeks(1);
+        Banner banner = new Banner();
+        banner.setStartDate(Date.valueOf(lastWeek));
+        banner.setEndDate(Date.valueOf(nextWeek));
+        banner.setText("Testing current banner");
+
+        bannerRepository.save(banner);
+
+        String expected = mapper.writeValueAsString(banner);
+
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(user)).
+        when().
+            get(BANNER_ENDPOINT + "current").
+        then().
+            statusCode(HttpStatus.SC_OK).
+            body(equalTo(expected));
+        //@formatter:on
+    }
+
+    @Test
+    public void testNoCurrentBanner() {
+        bannerRepository.deleteAll();
+
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(user)).
+        when().
+            get(BANNER_ENDPOINT + "current").
+        then().
+            statusCode(HttpStatus.SC_NOT_FOUND);
+        //@formatter:on
+    }
+
+    //endregion
+    //region POST add banner
+    @Test
+    public void testAddBannerWithoutPermissions() {
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(user)).
+        when().
+            body(banner).
+            contentType(ContentType.JSON).
+            post(BANNER_ENDPOINT).
+        then().
+            statusCode(HttpStatus.SC_FORBIDDEN).
+            body("message", equalTo("Access denied"));
+        //@formatter:on
+    }
+
+    @Test
+    public void testAddBannerWithPermissions() {
+        int oldSize = bannerRepository.findAll().size();
+
+        Banner newBanner = new Banner();
+        newBanner.setText("Welcome to AreaFiftyLan");
+        newBanner.setStartDate(Date.valueOf("2017-03-03"));
+        newBanner.setEndDate(Date.valueOf("2018-03-28"));
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(admin)).
+        when().
+            body(newBanner).
+            contentType(ContentType.JSON).
+            post(BANNER_ENDPOINT).
+        then().
+            statusCode(HttpStatus.SC_OK);
+        //@formatter:on
+
+        assertEquals(oldSize + 1, bannerRepository.findAll().size());
+    }
+
+    //endregion
+    //region POST update banner
+    @Test
+    public void testUpdateBannerWithoutPermissions() {
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(user)).
+        when().
+            body(banner).
+            contentType(ContentType.JSON).
+            post(BANNER_ENDPOINT + 1).
+        then().
+            statusCode(HttpStatus.SC_FORBIDDEN).
+            body("message", equalTo("Access denied"));
+        //@formatter:on
+    }
+
+    @Test
+    public void testUpdateBannerWithPermissions() {
+        Banner banner = bannerRepository.findAll().get(0);
+        banner.setText("Updated text");
+        System.out.println(banner);
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(admin)).
+        when().
+            body(banner).
+            contentType(ContentType.JSON).
+            post(BANNER_ENDPOINT + banner.getId()).
+        then().
+            statusCode(HttpStatus.SC_OK);
+        //@formatter:on
+
+        assertEquals(banner.getText(), bannerRepository.findOne(banner.getId()).getText());
+    }
+
+    //endregion
+    //region DELETE banner
+    @Test
+    public void testDeleteBannerWithoutPermissions() {
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(user)).
+        when().
+            delete(BANNER_ENDPOINT + 1).
+        then().
+            statusCode(HttpStatus.SC_FORBIDDEN).
+            body("message", equalTo("Access denied"));
+        //@formatter:on
+    }
+
+    @Test
+    public void testDeleteBannerWithPermissions() {
+        Long id = bannerRepository.findAll().get(0).getId();
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(admin)).
+        when().
+            delete(BANNER_ENDPOINT + id).
+        then().
+            statusCode(HttpStatus.SC_OK);
+        //@formatter:on
+
+        assertFalse(bannerRepository.exists(id));
+    }
+    //endregion
+    //region DELETE all banners
+
+    @Test
+    public void testDeleteAllBannersWithoutPermissions() {
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(user)).
+        when().
+            delete(BANNER_ENDPOINT).
+        then().
+            statusCode(HttpStatus.SC_FORBIDDEN).
+            body("message", equalTo("Access denied"));
+        //@formatter:on
+    }
+
+    @Test
+    public void testDeleteAllBannersWithPermissions() {
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(admin)).
+        when().
+            delete(BANNER_ENDPOINT).
+        then().
+            statusCode(HttpStatus.SC_OK);
+        //@formatter:on
+
+        assertEquals(0, bannerRepository.findAll().size());
+    }
+    //endregion
+}

--- a/src/test/java/ch/wisv/areafiftylan/integration/WebBannerIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/integration/WebBannerIntegrationTest.java
@@ -41,7 +41,7 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
         banner = new Banner();
         banners = new ArrayList<>();
         banner.setText("AreaFiftyLAN starts in less than a month! Make sure to get your tickets!");
-        banner.setStartDate(Date.valueOf("2017-02-03"));
+        banner.setStartDate(Date.valueOf("2018-02-03"));
         banner.setEndDate(Date.valueOf("2018-02-28"));
         banners.add(bannerRepository.save(banner));
 
@@ -162,29 +162,6 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
         //@formatter:on
 
         assertEquals(oldSize + 1, bannerRepository.findAll().size());
-    }
-
-    /**
-     * Note: this test is dependent on a banner existing (done in the setup) that
-     * partly covers the date range of the newly created banner.
-     */
-    @Test
-    public void testAddWithConflictingDates() {
-        Banner newBanner = new Banner();
-        newBanner.setStartDate(Date.valueOf("2017-02-04"));
-        newBanner.setEndDate(Date.valueOf("2018-02-27"));
-        newBanner.setText("Conflicting Dates");
-        //@formatter:off
-        given().
-            header(getXAuthTokenHeaderForUser(admin)).
-        when().
-            body(newBanner).
-            contentType(ContentType.JSON).
-            post(BANNER_ENDPOINT).
-        then().
-            statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR).
-            body("message", equalTo("An entity covering the given date range already exists"));
-        //@formatter:on
     }
 
     //endregion

--- a/src/test/java/ch/wisv/areafiftylan/integration/WebBannerIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/integration/WebBannerIntegrationTest.java
@@ -164,6 +164,29 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
         assertEquals(oldSize + 1, bannerRepository.findAll().size());
     }
 
+    /**
+     * Note: this test is dependent on a banner existing (done in the setup) that
+     * partly covers the date range of the newly created banner.
+     */
+    @Test
+    public void testAddWithConflictingDates() {
+        Banner newBanner = new Banner();
+        newBanner.setStartDate(Date.valueOf("2017-02-04"));
+        newBanner.setEndDate(Date.valueOf("2018-02-27"));
+        newBanner.setText("Conflicting Dates");
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(admin)).
+        when().
+            body(newBanner).
+            contentType(ContentType.JSON).
+            post(BANNER_ENDPOINT).
+        then().
+            statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR).
+            body("message", equalTo("An entity covering the given date range already exists"));
+        //@formatter:on
+    }
+
     //endregion
     //region POST update banner
     @Test

--- a/src/test/java/ch/wisv/areafiftylan/integration/WebBannerIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/integration/WebBannerIntegrationTest.java
@@ -98,8 +98,6 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
 
         bannerRepository.save(banner);
 
-        String expected = mapper.writeValueAsString(banner);
-
         //@formatter:off
         given().
             header(getXAuthTokenHeaderForUser(user)).
@@ -107,7 +105,7 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
             get(BANNER_ENDPOINT + "current").
         then().
             statusCode(HttpStatus.SC_OK).
-            body(equalTo(expected));
+            body("object.text",equalTo(banner.getText()));
         //@formatter:on
     }
 

--- a/src/test/java/ch/wisv/areafiftylan/integration/WebBannerIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/integration/WebBannerIntegrationTest.java
@@ -148,7 +148,7 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
 
         Banner newBanner = new Banner();
         newBanner.setText("Welcome to AreaFiftyLan");
-        newBanner.setStartDate(Date.valueOf("2017-03-03"));
+        newBanner.setStartDate(Date.valueOf("2018-03-03"));
         newBanner.setEndDate(Date.valueOf("2018-03-28"));
         //@formatter:off
         given().
@@ -221,6 +221,21 @@ public class WebBannerIntegrationTest extends XAuthIntegrationTest {
         //@formatter:on
 
         assertEquals(banner.getText(), bannerRepository.findOne(banner.getId()).getText());
+    }
+
+    @Test
+    public void testUpdateBannerNotFound() {
+        bannerRepository.deleteAll();
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(admin)).
+        when().
+            body(banner).
+            contentType(ContentType.JSON).
+            post(BANNER_ENDPOINT + 1).
+        then().
+            statusCode(HttpStatus.SC_NOT_FOUND);
+        //@formatter:on
     }
 
     //endregion


### PR DESCRIPTION
- `/web/banners` endpoint, to make it possible to schedule banners
- A `banner` has text and covers a date range in which the text should be displayed on the website
- Scheduling a new banner with a date range that is already (partially) covered by another banner is not possible (Note: this doesn't mean that conflicting date ranges cannot exists, since updates still can cause this)
- `/web/banners/current` returns the latest inserted scheduled banner where the current date (date when request was made) is within its date range

Closes #268
