### PR TITLE
Fix logging for production profile

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -35,7 +35,8 @@
         </root>
     </springProfile>
 
-    <springProfile name="prod">
+    <springProfile name="production">
+        <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
         <appender name="ROLLING-FILE"
                   class="ch.qos.logback.core.rolling.RollingFileAppender">
             <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
@@ -66,6 +67,7 @@
         </appender>
 
         <root level="ERROR">
+            <appender-ref ref="CONSOLE"/>
             <appender-ref ref="ROLLING-FILE"/>
         </root>
     </springProfile>


### PR DESCRIPTION
The profile active on production is not `prod` but `production`. This PR fixes logging for that profile and enables consile logging as well.

Fixes #464 