### PR TITLE
Fix Docker startup

### DIFF
--- a/src/main/resources/config/application-production.yml
+++ b/src/main/resources/config/application-production.yml
@@ -4,6 +4,9 @@ flyway:
 spring.jpa.hibernate.ddl-auto: validate
 spring.jpa.properties.hibernate.hbm2ddl.auto: none
 
+logging:
+  file: /tmp/logs/lancie-api.log
+
 ## AREA FIFTYLAN SETTINGS
 a5l:
   paymentReturnUrl: https://areafiftylan.nl/order-check


### PR DESCRIPTION
This PR moves the logging for the production profile to a location where a non-root user can write the logs

Fixes #471 