### PR TITLE
Add global ticket limit to available response

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/products/controller/TicketRestController.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/controller/TicketRestController.java
@@ -18,8 +18,8 @@
 package ch.wisv.areafiftylan.products.controller;
 
 import ch.wisv.areafiftylan.exception.TicketTransferTokenException;
+import ch.wisv.areafiftylan.products.model.AvailableTicketsDTO;
 import ch.wisv.areafiftylan.products.model.Ticket;
-import ch.wisv.areafiftylan.products.model.TicketInformationResponse;
 import ch.wisv.areafiftylan.products.model.TicketOption;
 import ch.wisv.areafiftylan.products.model.TicketType;
 import ch.wisv.areafiftylan.products.service.OrderService;
@@ -31,6 +31,7 @@ import net.logstash.logback.argument.StructuredArguments;
 import net.logstash.logback.marker.Markers;
 import org.slf4j.Marker;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -48,6 +49,9 @@ import static ch.wisv.areafiftylan.utils.ResponseEntityBuilder.createResponseEnt
 public class TicketRestController {
     private final TicketService ticketService;
     private final OrderService orderService;
+
+    @Value("${a5l.ticketLimit}")
+    private int TICKET_LIMIT;
 
     private Marker controllerMarker = Markers.append("controller", "tickets");
 
@@ -105,8 +109,8 @@ public class TicketRestController {
      * @return A collection of all TicketTypes and their availability
      */
     @GetMapping("/available")
-    public Collection<TicketInformationResponse> getAvailableTickets() {
-        return orderService.getAvailableTickets();
+    public AvailableTicketsDTO getAvailableTickets() {
+        return new AvailableTicketsDTO(orderService.getAvailableTickets(), TICKET_LIMIT);
     }
 
     @PreAuthorize("isAuthenticated()")

--- a/src/main/java/ch/wisv/areafiftylan/products/model/AvailableTicketsDTO.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/model/AvailableTicketsDTO.java
@@ -2,12 +2,12 @@ package ch.wisv.areafiftylan.products.model;
 
 import ch.wisv.areafiftylan.utils.view.View;
 import com.fasterxml.jackson.annotation.JsonView;
-import lombok.Data;
+import lombok.AllArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 import java.util.Collection;
 
-@Data
+@AllArgsConstructor
 public class AvailableTicketsDTO {
 
     @JsonView(View.Public.class)

--- a/src/main/java/ch/wisv/areafiftylan/products/model/AvailableTicketsDTO.java
+++ b/src/main/java/ch/wisv/areafiftylan/products/model/AvailableTicketsDTO.java
@@ -1,0 +1,20 @@
+package ch.wisv.areafiftylan.products.model;
+
+import ch.wisv.areafiftylan.utils.view.View;
+import com.fasterxml.jackson.annotation.JsonView;
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+import java.util.Collection;
+
+@Data
+public class AvailableTicketsDTO {
+
+    @JsonView(View.Public.class)
+    @NotNull
+    private final Collection<TicketInformationResponse> ticketTypes;
+
+    @JsonView(View.Public.class)
+    @NotNull
+    private final Integer ticketLimit;
+}

--- a/src/main/java/ch/wisv/areafiftylan/seats/model/SeatmapResponse.java
+++ b/src/main/java/ch/wisv/areafiftylan/seats/model/SeatmapResponse.java
@@ -19,12 +19,14 @@ package ch.wisv.areafiftylan.seats.model;
 
 import ch.wisv.areafiftylan.utils.view.View;
 import com.fasterxml.jackson.annotation.JsonView;
-import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import java.util.List;
 import java.util.Map;
 
-@Data
+@AllArgsConstructor
+@Getter
 public class SeatmapResponse {
 
     @JsonView(View.Public.class)

--- a/src/test/java/ch/wisv/areafiftylan/integration/TicketRestIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/integration/TicketRestIntegrationTest.java
@@ -35,6 +35,7 @@ import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
@@ -51,6 +52,9 @@ public class TicketRestIntegrationTest extends XAuthIntegrationTest {
     private final String TICKETS_ENDPOINT = "/tickets";
     private final String TRANSFER_ENDPOINT = TICKETS_ENDPOINT + "/transfer";
     private final String TRANSPORT_ENDPOINT = TICKETS_ENDPOINT + "/transport";
+
+    @Value("${a5l.ticketLimit}")
+    private int TICKET_LIMIT;
 
     @Autowired
     private TicketRepository ticketRepository;
@@ -111,12 +115,13 @@ public class TicketRestIntegrationTest extends XAuthIntegrationTest {
             get(TICKETS_ENDPOINT + "/available").
         then().
             statusCode(HttpStatus.SC_OK).
-            body("ticketType", is(ticketTypes.stream()
+            body("ticketTypes.ticketType", is(ticketTypes.stream()
                     .map(TicketType::getName)
                     .collect(Collectors.toList()))).
-            body("price", is(ticketTypes.stream()
+            body("ticketTypes.price", is(ticketTypes.stream()
                     .map(TicketType::getPrice)
-                    .collect(Collectors.toList())));
+                    .collect(Collectors.toList()))).
+            body("ticketLimit", is(TICKET_LIMIT));
         //@formatter:on
     }
 


### PR DESCRIPTION
We're now adding the global ticket limit. Previously there was no way to let our users know whether the event was sold out, now there is.