### PR TITLE
Fix Export endpoint nullpointer

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/users/model/UserExportDTO.java
+++ b/src/main/java/ch/wisv/areafiftylan/users/model/UserExportDTO.java
@@ -10,9 +10,9 @@ import java.util.List;
 @AllArgsConstructor
 public class UserExportDTO {
 
+    private Long userId;
     private String email;
     private String passwordHash;
     private String displayname;
-    private Long userId;
     private List<String> seat;
 }

--- a/src/main/java/ch/wisv/areafiftylan/utils/ExportController.java
+++ b/src/main/java/ch/wisv/areafiftylan/utils/ExportController.java
@@ -49,17 +49,11 @@ public class ExportController {
                 ticketService.getAllTickets().stream()
                         .filter(Ticket::isValid)
                         .map(Ticket::getOwner)
-                        .map(user -> {
-                            String displayName = user.getProfile() != null ? user.getProfile().getDisplayName() : null;
-
-                            List<String> seats = Collections.emptyList();
-                            if (!seatMap.isEmpty()) {
-                                seatMap.get(user.getId()).forEach(seat -> seats.add(seat.toString()));
-                            }
-
-                            return new UserExportDTO(user.getEmail(), user.getPassword(),
-                                    displayName, user.getId(), seats);
-                        })
+                        .map(user -> new UserExportDTO(user.getId(), user.getEmail(), user.getPassword(),
+                                user.getProfile() != null ? user.getProfile().getDisplayName() : null,
+                                seatMap.getOrDefault(user.getId(), Collections.emptyList()).stream()
+                                        .map(Seat::toString).collect(Collectors.toList())
+                        ))
                         .collect(Collectors.toList()));
 
         exportMap.put("teams",

--- a/src/main/java/ch/wisv/areafiftylan/utils/ExportController.java
+++ b/src/main/java/ch/wisv/areafiftylan/utils/ExportController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,10 +49,17 @@ public class ExportController {
                 ticketService.getAllTickets().stream()
                         .filter(Ticket::isValid)
                         .map(Ticket::getOwner)
-                        .map(user -> new UserExportDTO(user.getEmail(), user.getPassword(),
-                                user.getProfile().getDisplayName(), user.getId(),
-                                seatMap.get(user.getId()).stream()
-                                        .map(Seat::toString).collect(Collectors.toList())))
+                        .map(user -> {
+                            String displayName = user.getProfile() != null ? user.getProfile().getDisplayName() : null;
+
+                            List<String> seats = Collections.emptyList();
+                            if (!seatMap.isEmpty()) {
+                                seatMap.get(user.getId()).forEach(seat -> seats.add(seat.toString()));
+                            }
+
+                            return new UserExportDTO(user.getEmail(), user.getPassword(),
+                                    displayName, user.getId(), seats);
+                        })
                         .collect(Collectors.toList()));
 
         exportMap.put("teams",

--- a/src/test/java/ch/wisv/areafiftylan/integration/TicketRestIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/integration/TicketRestIntegrationTest.java
@@ -733,4 +733,32 @@ public class TicketRestIntegrationTest extends XAuthIntegrationTest {
             statusCode(HttpStatus.SC_OK);
         //@formatter:on
     }
+
+
+    @Test
+    public void testExportAsAnon(){
+        //@formatter:off
+        given().
+        when().
+            get("/export").
+        then().
+            statusCode(HttpStatus.SC_FORBIDDEN);
+        //@formatter:on
+    }
+
+    @Test
+    public void testGetExportAsAdmin() {
+        User admin = createAdmin();
+        createTicket(admin, Collections.singletonList(PICKUP_SERVICE));
+
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(admin)).
+        when().
+            get("/export").
+        then().
+            statusCode(HttpStatus.SC_OK);
+        //@formatter:on
+
+    }
 }

--- a/src/test/java/ch/wisv/areafiftylan/integration/UserRestIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/integration/UserRestIntegrationTest.java
@@ -775,17 +775,6 @@ public class UserRestIntegrationTest extends XAuthIntegrationTest {
         //@formatter:on
     }
 
-    @Test
-    public void testExportAsAnon(){
-        //@formatter:off
-        given().
-        when().
-            get("/export").
-        then().
-            statusCode(HttpStatus.SC_FORBIDDEN);
-        //@formatter:on
-    }
-
     //TODO: Move to SchedulerTest
 /*    @Test
     public void testExpiredUsersNoneExpired() {


### PR DESCRIPTION
The testdata didn't cover the possible scenario's we have in the live database, so the export endpoint resulted in a nullpointer.

This PR expands the export method for better null checking