### PR TITLE
Remove USER command from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
 FROM wisvch/spring-boot-base:1
 COPY ./build/libs/lancie-api.jar /srv/lancie-api.jar
-USER spring-boot
 CMD ["/srv/lancie-api.jar"]


### PR DESCRIPTION
It is now included in the base image.