### PR TITLE
Token persistence issue fixes

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/security/JsonLoginAuthenticationAttemptHandler.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/JsonLoginAuthenticationAttemptHandler.java
@@ -54,6 +54,9 @@ public class JsonLoginAuthenticationAttemptHandler implements AuthenticationSucc
             attemptsCache.invalidate(authentication.getName());
             log.warn("Successful authentication after {} attempts", previousAttempts,
                     StructuredArguments.v("user_id", ((User) authentication.getPrincipal()).getId()));
+        } else {
+            log.info("Successful authentication for user {}", ((User) authentication.getPrincipal()).getId(),
+                    StructuredArguments.v("user_id", ((User) authentication.getPrincipal()).getId()));
         }
 
         response.setHeader("X-Auth-Token", authenticationService.createNewAuthToken(authentication.getName()));

--- a/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationService.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationService.java
@@ -22,4 +22,6 @@ public interface AuthenticationService {
     String createNewAuthToken(String email);
 
     void removeAuthToken(String xAuth);
+
+    void removeAllAuthTokens();
 }

--- a/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/authentication/AuthenticationServiceImpl.java
@@ -24,10 +24,12 @@ import ch.wisv.areafiftylan.security.token.repository.AuthenticationTokenReposit
 import ch.wisv.areafiftylan.users.model.User;
 import ch.wisv.areafiftylan.users.service.UserService;
 import com.google.common.base.Strings;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 public class AuthenticationServiceImpl implements AuthenticationService {
 
     private final AuthenticationTokenRepository authenticationTokenRepository;
@@ -67,5 +69,11 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 
         token.revoke();
         authenticationTokenRepository.saveAndFlush(token);
+    }
+
+    @Override
+    public void removeAllAuthTokens() {
+        authenticationTokenRepository.deleteAll();
+        log.info("Deleted all authentication tokens");
     }
 }

--- a/src/main/java/ch/wisv/areafiftylan/security/token/repository/TeamInviteTokenRepository.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/token/repository/TeamInviteTokenRepository.java
@@ -18,6 +18,7 @@
 package ch.wisv.areafiftylan.security.token.repository;
 
 import ch.wisv.areafiftylan.security.token.TeamInviteToken;
+import ch.wisv.areafiftylan.teams.model.Team;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
@@ -29,5 +30,6 @@ public interface TeamInviteTokenRepository extends TokenRepository<TeamInviteTok
 
     Collection<TeamInviteToken> findByTeamId(Long teamId);
 
+    void deleteByTeam(Team team);
 
 }

--- a/src/main/java/ch/wisv/areafiftylan/teams/service/TeamServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/teams/service/TeamServiceImpl.java
@@ -32,6 +32,7 @@ import com.google.common.base.Strings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -111,6 +112,7 @@ public class TeamServiceImpl implements TeamService {
     }
 
     @Override
+    @Transactional
     public Team delete(Long teamId) {
         Team team = teamRepository.getOne(teamId);
         teamInviteTokenRepository.deleteByTeam(team);
@@ -200,6 +202,7 @@ public class TeamServiceImpl implements TeamService {
     }
 
     @Override
+    @Transactional
     public boolean removeMember(Long teamId, String email) {
         Team team = getTeamById(teamId);
         User user = userService.getUserByEmail(email);

--- a/src/main/java/ch/wisv/areafiftylan/teams/service/TeamServiceImpl.java
+++ b/src/main/java/ch/wisv/areafiftylan/teams/service/TeamServiceImpl.java
@@ -112,11 +112,8 @@ public class TeamServiceImpl implements TeamService {
 
     @Override
     public Team delete(Long teamId) {
-        List<TeamInviteResponse> invites = findTeamInvitesByTeamId(teamId);
-        invites.stream().
-                map(TeamInviteResponse::getToken).
-                forEach(this::revokeInvite);
         Team team = teamRepository.getOne(teamId);
+        teamInviteTokenRepository.deleteByTeam(team);
         teamRepository.delete(team);
         return team;
     }

--- a/src/test/java/ch/wisv/areafiftylan/integration/TeamRestIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/integration/TeamRestIntegrationTest.java
@@ -901,6 +901,33 @@ public class TeamRestIntegrationTest extends XAuthIntegrationTest {
     }
 
     @Test
+    public void testRemoveCaptainAsCaptainWithOpenInvite() {
+        User captain = createUser();
+        User member = createUser();
+        Team team = createTeamWithCaptain(captain);
+
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(captain)).
+        when().
+            body(member.getEmail()).
+            post(TEAM_ENDPOINT + team.getId() + "/invites").
+        then().
+            statusCode(HttpStatus.SC_OK);
+        //@formatter:on
+
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(captain)).
+        when().
+            body(captain.getEmail()).
+            delete(TEAM_ENDPOINT + team.getId() + "/members").
+        then().
+            statusCode(HttpStatus.SC_OK);
+        //@formatter:on
+    }
+
+    @Test
     public void testRemoveCaptainAsAdmin() {
         User admin = createAdmin();
         User captain = createUser();
@@ -973,5 +1000,23 @@ public class TeamRestIntegrationTest extends XAuthIntegrationTest {
             statusCode(HttpStatus.SC_OK);
         //@formatter:on
     }
+
+    @Test
+    public void testRemoveEmptyTeamAsCaptain() {
+        User captain = createUser();
+        User user = createUser();
+        Team team = createTeamWithCaptain(captain);
+
+        //@formatter:off
+        given().
+            header(getXAuthTokenHeaderForUser(captain)).
+        when().
+            body(user.getEmail()).
+            delete(TEAM_ENDPOINT + team.getId() + "/members").
+        then().
+            statusCode(HttpStatus.SC_OK);
+        //@formatter:on
+    }
     //endregion
+
 }


### PR DESCRIPTION
This PR fixes two minor token-related issues.

First issue, #473, extremely hard to reproduce but to make sure no conflicts occur between restarts, we delete all auth tokens on startup. This means all users will need to login after a new deploy.

Second issue #484 was caused by a cascading operation, as we didn't delete invites on revoke. When we wanted to delete a team, all previous invites were still persisted, which would result in orphaned invites. This PR removes all invites on deletion (and adds a Transactional annotation in case either operation fails)

Fixes #484 
Fixes #473 