### PR TITLE
Increase order limit from 5 to 15

### DIFF
--- a/src/main/resources/config/application-production.yml
+++ b/src/main/resources/config/application-production.yml
@@ -19,7 +19,7 @@ a5l:
         enabled: true
         minute: 10
 
-    orderLimit: 5
+    orderLimit: 15
     ticketLimit: 220
     orderKeepAlive: 15
 spring:


### PR DESCRIPTION
To make it easier for bigger LAN groups to buy tickets in bulk, LANcie 2018/2019 decided to increase to order limit to 15.