### PR TITLE
Add current timestamp to Jib image

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,9 @@ jib {
             implementation = 'com.google.cloud.tools.jib.gradle.extension.springboot.JibSpringBootExtension'
         }
     }
+    container {
+        creationTime = 'USE_CURRENT_TIMESTAMP'
+    }
 }
 
 jacocoTestReport {


### PR DESCRIPTION
Without this setting, all images are created with timestamp 0 (1 jan 1970), which messes up the deployment