### PR TITLE
Fix missing CORS response header

### DIFF
--- a/src/main/java/ch/wisv/areafiftylan/security/SecurityConfiguration.java
+++ b/src/main/java/ch/wisv/areafiftylan/security/SecurityConfiguration.java
@@ -96,7 +96,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 new JsonLoginAuthenticationAttemptHandler(authenticationService);
         http.logout().logoutSuccessHandler(attemptHandler);
 
-        http.authorizeRequests().expressionHandler(webExpressionHandler()).requestMatchers(EndpointRequest.to("health"))
+        http.cors().and().authorizeRequests().expressionHandler(webExpressionHandler()).requestMatchers(EndpointRequest.to("health"))
                 .permitAll().requestMatchers(EndpointRequest.toAnyEndpoint()).hasRole("ADMIN").anyRequest().permitAll();
 
         // We use custom Authentication Tokens, making csrf redundant

--- a/src/test/java/ch/wisv/areafiftylan/integration/AuthenticationIntegrationTest.java
+++ b/src/test/java/ch/wisv/areafiftylan/integration/AuthenticationIntegrationTest.java
@@ -78,7 +78,8 @@ public class AuthenticationIntegrationTest extends XAuthIntegrationTest {
 
         response.then().
                 statusCode(HttpStatus.SC_OK).
-                header("X-Auth-Token", containsString(authenticationToken.get().getToken()));
+                header("X-Auth-Token", containsString(authenticationToken.get().getToken())).
+                header("Access-Control-Allow-Origin", "*");
         //@formatter:on
     }
 


### PR DESCRIPTION
As part of #531, we replaced the custom CORS filter by a bean in the Spring Configuration. Turns out you need to tell Spring Security about that too. This PR adds CORS to Spring Security, and adds a test to check for the required header.