### PR TITLE
Bump year to 2022

### DIFF
--- a/src/main/resources/config/application-production.yml
+++ b/src/main/resources/config/application-production.yml
@@ -13,7 +13,7 @@ a5l:
         sender: LANcie <lancie@ch.tudelft.nl>
         contact: LANcie <lancie@ch.tudelft.nl>
         confirmUrl: https://areafiftylan.nl/register-confirm
-        year: 2020
+        year: 2022
     ratelimit:
         enabled: false
         minute: 10

--- a/src/main/resources/config/application-production.yml
+++ b/src/main/resources/config/application-production.yml
@@ -2,7 +2,7 @@ logging:
     file:
         name: /tmp/logs/lancie-api.log
 
-## AREA FIFTYLAN SETTINGS
+## AREA FIFTYLAN SETTINGS 2022
 a5l:
     paymentReturnUrl: https://areafiftylan.nl/order-check
     user:

--- a/src/main/resources/config/application-production.yml
+++ b/src/main/resources/config/application-production.yml
@@ -17,7 +17,6 @@ a5l:
     ratelimit:
         enabled: false
         minute: 10
-
     orderLimit: 15
     ticketLimit: 220
     orderKeepAlive: 15


### PR DESCRIPTION
This commit timetravels the lancie's [MailServiceImpl](https://github.com/AreaFiftyLAN/lancie-api/blob/cb4019ead42b6bd0b56cce406e005d1516744708/src/main/java/ch/wisv/areafiftylan/utils/mail/MailServiceImpl.java) from 2020 to 2022.