### PR TITLE
Add pull_request event trigger

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,6 +2,7 @@ name: Test and Deploy
 on:
   push:
   workflow_dispatch:
+  pull_request:
 jobs:
   testAndDeploy:
     name: Test and Deploy Docker Image


### PR DESCRIPTION
PR's from forks don't trigger actions, causing a deadlock. This triggers actions on PR's as well.